### PR TITLE
Chacha improvements

### DIFF
--- a/src/chacha/mod.rs
+++ b/src/chacha/mod.rs
@@ -1,0 +1,23 @@
+#[cfg(not(all(
+    any(target_arch = "x86", target_arch = "x86_64"),
+    any(target_feature = "sse2", target_feature = "avx2")
+)))]
+mod reference;
+
+#[cfg(not(all(
+    any(target_arch = "x86", target_arch = "x86_64"),
+    any(target_feature = "sse2", target_feature = "avx2")
+)))]
+pub(crate) type ChaChaEngine = reference::State;
+
+#[cfg(all(
+    any(target_arch = "x86", target_arch = "x86_64"),
+    target_feature = "sse2",
+))]
+mod sse2;
+
+#[cfg(all(
+    any(target_arch = "x86", target_arch = "x86_64"),
+    target_feature = "sse2",
+))]
+pub(crate) type ChaChaEngine = sse2::State;

--- a/src/chacha/reference.rs
+++ b/src/chacha/reference.rs
@@ -1,0 +1,199 @@
+use crate::cryptoutil::{read_u32_le, write_u32v_le};
+use crate::simd::u32x4;
+
+#[derive(Clone)]
+pub(crate) struct State {
+    a: u32x4,
+    b: u32x4,
+    c: u32x4,
+    d: u32x4,
+}
+
+// b row <<< 8, c row <<< 16, d row <<< 24
+macro_rules! swizzle {
+    ($b: expr, $c: expr, $d: expr) => {{
+        let u32x4(b10, b11, b12, b13) = $b;
+        $b = u32x4(b11, b12, b13, b10);
+        let u32x4(c10, c11, c12, c13) = $c;
+        $c = u32x4(c12, c13, c10, c11);
+        let u32x4(d10, d11, d12, d13) = $d;
+        $d = u32x4(d13, d10, d11, d12);
+    }};
+}
+
+macro_rules! state_to_buffer {
+    ($state: expr, $output: expr) => {{
+        let u32x4(a1, a2, a3, a4) = $state.a;
+        let u32x4(b1, b2, b3, b4) = $state.b;
+        let u32x4(c1, c2, c3, c4) = $state.c;
+        let u32x4(d1, d2, d3, d4) = $state.d;
+        let lens = [
+            a1, a2, a3, a4, b1, b2, b3, b4, c1, c2, c3, c4, d1, d2, d3, d4,
+        ];
+        write_u32v_le($output, &lens)
+    }};
+}
+
+macro_rules! round {
+    ($state: expr) => {{
+        $state.a = $state.a + $state.b;
+        rotate!($state.d, $state.a, S16);
+        $state.c = $state.c + $state.d;
+        rotate!($state.b, $state.c, S12);
+        $state.a = $state.a + $state.b;
+        rotate!($state.d, $state.a, S8);
+        $state.c = $state.c + $state.d;
+        rotate!($state.b, $state.c, S7);
+    }};
+}
+
+macro_rules! rotate {
+    ($a: expr, $b: expr, $c:expr) => {{
+        let v = $a ^ $b;
+        let r = S32 - $c;
+        let right = v >> r;
+        $a = (v << $c) ^ right
+    }};
+}
+
+static S32: u32x4 = u32x4(32, 32, 32, 32);
+static S16: u32x4 = u32x4(16, 16, 16, 16);
+static S12: u32x4 = u32x4(12, 12, 12, 12);
+static S8: u32x4 = u32x4(8, 8, 8, 8);
+static S7: u32x4 = u32x4(7, 7, 7, 7);
+
+impl State {
+    // state initialization constant le-32bit array of b"expand 16-byte k"
+    const CST16: [u32; 4] = [0x61707865, 0x3120646e, 0x79622d36, 0x6b206574];
+    // state initialization constant le-32bit array of b"expand 32-byte k"
+    const CST32: [u32; 4] = [0x61707865, 0x3320646e, 0x79622d32, 0x6b206574];
+
+    // state is initialized to the following 32 bits elements:
+    // C1 C2 C3 C4
+    // K1 K2 K3 K4
+    // K1 K2 K3 K4 (16 bytes key) or K5 K6 K7 K8 (32 bytes keys)
+    // N1 N2 N3 N4 (16 bytes nonce) or 0 N1 N2 N3 (12 bytes nonce) or 0 0 N1 N2 (8 bytes nonce)
+
+    /// Initialize the state with key and nonce
+    pub(crate) fn init(key: &[u8], nonce: &[u8]) -> Self {
+        let (a, b, c) = match key.len() {
+            16 => Self::init_key16(key),
+            32 => Self::init_key32(key),
+            _ => unreachable!(),
+        };
+        let d = Self::init_nonce(nonce);
+        Self { a, b, c, d }
+    }
+
+    #[inline]
+    fn init_key16(key: &[u8]) -> (u32x4, u32x4, u32x4) {
+        let constant: &[u32; 4] = &Self::CST16;
+        let c = u32x4(constant[0], constant[1], constant[2], constant[3]);
+        let k1 = u32x4(
+            read_u32_le(&key[0..4]),
+            read_u32_le(&key[4..8]),
+            read_u32_le(&key[8..12]),
+            read_u32_le(&key[12..16]),
+        );
+        (c, k1, k1)
+    }
+
+    #[inline]
+    fn init_key32(key: &[u8]) -> (u32x4, u32x4, u32x4) {
+        let constant: &[u32; 4] = &Self::CST32;
+        let c = u32x4(constant[0], constant[1], constant[2], constant[3]);
+        let k1 = u32x4(
+            read_u32_le(&key[0..4]),
+            read_u32_le(&key[4..8]),
+            read_u32_le(&key[8..12]),
+            read_u32_le(&key[12..16]),
+        );
+        let k2 = u32x4(
+            read_u32_le(&key[16..20]),
+            read_u32_le(&key[20..24]),
+            read_u32_le(&key[24..28]),
+            read_u32_le(&key[28..32]),
+        );
+        (c, k1, k2)
+    }
+
+    #[inline]
+    fn init_nonce(nonce: &[u8]) -> u32x4 {
+        if nonce.len() == 16 {
+            u32x4(
+                read_u32_le(&nonce[0..4]),
+                read_u32_le(&nonce[4..8]),
+                read_u32_le(&nonce[8..12]),
+                read_u32_le(&nonce[12..16]),
+            )
+        } else if nonce.len() == 12 {
+            u32x4(
+                0,
+                read_u32_le(&nonce[0..4]),
+                read_u32_le(&nonce[4..8]),
+                read_u32_le(&nonce[8..12]),
+            )
+        } else {
+            u32x4(0, 0, read_u32_le(&nonce[0..4]), read_u32_le(&nonce[4..8]))
+        }
+    }
+
+    #[inline]
+    pub(crate) fn round20(&mut self) {
+        for _ in 0..10 {
+            round!(self);
+            swizzle!(self.b, self.c, self.d);
+            round!(self);
+            swizzle!(self.d, self.c, self.b);
+        }
+    }
+
+    #[inline]
+    #[allow(dead_code)]
+    pub(crate) fn round12(&mut self) {
+        for _ in 0..8 {
+            round!(self);
+            swizzle!(self.b, self.c, self.d);
+            round!(self);
+            swizzle!(self.d, self.c, self.b);
+        }
+    }
+
+    #[inline]
+    #[allow(dead_code)]
+    pub(crate) fn round8(&mut self) {
+        for _ in 0..4 {
+            round!(self);
+            swizzle!(self.b, self.c, self.d);
+            round!(self);
+            swizzle!(self.d, self.c, self.b);
+        }
+    }
+
+    #[inline]
+    pub(crate) fn increment(&mut self) {
+        self.d = self.d + u32x4(1, 0, 0, 0);
+    }
+
+    #[inline]
+    /// Add back the initial state
+    pub(crate) fn add_back(&mut self, initial: &Self) {
+        self.a = self.a + initial.a;
+        self.b = self.b + initial.b;
+        self.c = self.c + initial.c;
+        self.d = self.d + initial.d;
+    }
+
+    #[inline]
+    pub(crate) fn output_bytes(&self, output: &mut [u8]) {
+        state_to_buffer!(self, output);
+    }
+
+    #[inline]
+    pub(crate) fn output_ad_bytes(&self, output: &mut [u8; 32]) {
+        let u32x4(a1, a2, a3, a4) = self.a;
+        let u32x4(d1, d2, d3, d4) = self.d;
+        let lens = [a1, a2, a3, a4, d1, d2, d3, d4];
+        write_u32v_le(&mut output[..], &lens[..]);
+    }
+}

--- a/src/chacha/sse2.rs
+++ b/src/chacha/sse2.rs
@@ -1,0 +1,239 @@
+#![allow(clippy::cast_ptr_alignment)]
+
+#[cfg(target_arch = "x86")]
+use core::arch::x86::*;
+
+#[cfg(target_arch = "x86_64")]
+use core::arch::x86_64::*;
+
+use core::convert::TryInto;
+
+#[derive(Clone)]
+pub(crate) struct State {
+    a: __m128i,
+    b: __m128i,
+    c: __m128i,
+    d: __m128i,
+}
+
+#[repr(align(16))]
+pub struct Align128([u32; 4]);
+
+impl Align128 {
+    pub fn zero() -> Self {
+        Self([0u32; 4])
+    }
+
+    #[inline]
+    fn to_m128i(&self) -> __m128i {
+        unsafe { _mm_load_si128(self.0.as_ptr() as *const __m128i) }
+    }
+
+    #[inline]
+    fn from_m128i(&mut self, v: __m128i) {
+        unsafe { _mm_store_si128(self.0.as_mut_ptr() as *mut __m128i, v) }
+    }
+}
+
+#[inline]
+macro_rules! swizzle {
+    ($b: expr, $c: expr, $d: expr) => {
+        $b = _mm_shuffle_epi32($b, 0b00111001); // <<< 8
+        $c = _mm_shuffle_epi32($c, 0b01001110); // <<< 16
+        $d = _mm_shuffle_epi32($d, 0b10010011); // <<< 24
+    };
+}
+
+macro_rules! add_rotate_xor {
+    ($a: expr, $b: expr, $c: expr, $d: expr) => {
+        // a += b; c ^= a; c <<<= d;
+        $a = _mm_add_epi32($a, $b);
+        $c = _mm_xor_si128($c, $a);
+        $c = _mm_xor_si128(_mm_slli_epi32($c, $d), _mm_srli_epi32($c, 32 - $d));
+    };
+}
+
+macro_rules! round {
+    ($a: expr, $b: expr, $c: expr, $d: expr) => {
+        add_rotate_xor!($a, $b, $d, 16);
+        add_rotate_xor!($c, $d, $b, 12);
+        add_rotate_xor!($a, $b, $d, 8);
+        add_rotate_xor!($c, $d, $b, 7);
+    };
+}
+
+impl State {
+    // state initialization constant le-32bit array of b"expand 16-byte k"
+    const CST16: [u32; 4] = [0x61707865, 0x3120646e, 0x79622d36, 0x6b206574];
+
+    // state initialization constant le-32bit array of b"expand 32-byte k"
+    const CST32: [u32; 4] = [0x61707865, 0x3320646e, 0x79622d32, 0x6b206574];
+
+    // state is initialized to the following 32 bits elements:
+    // C1 C2 C3 C4
+    // K1 K2 K3 K4
+    // K1 K2 K3 K4 (16 bytes key) or K5 K6 K7 K8 (32 bytes keys)
+    // N1 N2 N3 N4 (16 bytes nonce) or 0 N1 N2 N3 (12 bytes nonce) or 0 0 N1 N2 (8 bytes nonce)
+
+    #[inline]
+    unsafe fn constant32() -> __m128i {
+        _mm_loadu_si128(Self::CST32.as_ptr() as *const __m128i)
+    }
+
+    #[inline]
+    unsafe fn constant16() -> __m128i {
+        _mm_loadu_si128(Self::CST16.as_ptr() as *const __m128i)
+    }
+
+    #[inline]
+    fn key32(key: &[u8]) -> (__m128i, __m128i, __m128i) {
+        let k = key.as_ptr();
+        unsafe {
+            (
+                Self::constant32(),
+                _mm_loadu_si128(k as *const __m128i),
+                _mm_loadu_si128(k.add(16) as *const __m128i),
+            )
+        }
+    }
+
+    #[inline]
+    fn key16(key: &[u8]) -> (__m128i, __m128i, __m128i) {
+        let k = unsafe { _mm_loadu_si128(key.as_ptr() as *const __m128i) };
+        (unsafe { Self::constant16() }, k, k)
+    }
+
+    #[inline]
+    fn nonce(nonce: &[u8]) -> __m128i {
+        if nonce.len() == 16 {
+            unsafe { _mm_loadu_si128(nonce.as_ptr() as *const __m128i) }
+        } else {
+            let mut n = Align128::zero();
+            if nonce.len() == 12 {
+                n.0[1] = u32::from_le_bytes(nonce[0..4].try_into().unwrap());
+                n.0[2] = u32::from_le_bytes(nonce[4..8].try_into().unwrap());
+                n.0[3] = u32::from_le_bytes(nonce[8..12].try_into().unwrap());
+                n.to_m128i()
+            } else if nonce.len() == 8 {
+                n.0[2] = u32::from_le_bytes(nonce[0..4].try_into().unwrap());
+                n.0[3] = u32::from_le_bytes(nonce[4..8].try_into().unwrap());
+                n.to_m128i()
+            } else {
+                unreachable!()
+            }
+        }
+    }
+
+    /// Initialize the state with key and nonce
+    pub(crate) fn init(key: &[u8], nonce: &[u8]) -> Self {
+        let (a, b, c) = match key.len() {
+            32 => Self::key32(key),
+            16 => Self::key16(key),
+            _ => unreachable!(),
+        };
+        let d = Self::nonce(nonce);
+        Self { a, b, c, d }
+    }
+
+    #[inline]
+    pub(crate) fn round20(&mut self) {
+        unsafe {
+            for _ in 0..10 {
+                round!(self.a, self.b, self.c, self.d);
+                swizzle!(self.b, self.c, self.d);
+                round!(self.a, self.b, self.c, self.d);
+                swizzle!(self.d, self.c, self.b);
+            }
+        }
+    }
+
+    #[inline]
+    pub(crate) fn increment(&mut self) {
+        let mut align = Align128::zero();
+        align.from_m128i(self.d);
+        let (a, overflowed) = align.0[0].overflowing_add(1);
+        if overflowed {
+            align.0[1] = align.0[1].wrapping_add(1);
+        }
+        align.0[0] = a;
+        self.d = align.to_m128i();
+    }
+
+    #[inline]
+    /// Add back the initial state
+    pub(crate) fn add_back(&mut self, initial: &Self) {
+        unsafe {
+            self.a = _mm_add_epi32(self.a, initial.a);
+            self.b = _mm_add_epi32(self.b, initial.b);
+            self.c = _mm_add_epi32(self.c, initial.c);
+            self.d = _mm_add_epi32(self.d, initial.d);
+        }
+    }
+
+    #[inline]
+    pub(crate) fn output_bytes(&self, output: &mut [u8]) {
+        #[allow(clippy::cast_ptr_alignment)]
+        let o = output.as_mut_ptr() as *mut __m128i;
+        unsafe {
+            _mm_storeu_si128(o, self.a);
+            _mm_storeu_si128(o.add(1), self.b);
+            _mm_storeu_si128(o.add(2), self.c);
+            _mm_storeu_si128(o.add(3), self.d);
+        }
+    }
+
+    #[inline]
+    pub(crate) fn output_ad_bytes(&self, output: &mut [u8; 32]) {
+        #[allow(clippy::cast_ptr_alignment)]
+        let o = output.as_mut_ptr() as *mut __m128i;
+        unsafe {
+            _mm_storeu_si128(o, self.a);
+            _mm_storeu_si128(o.add(1), self.d);
+        }
+    }
+}
+
+mod test {
+    /*
+    use super::super::reference;
+    use super::*;
+
+    fn assert_state_equivalent(doing: &'static str, refere: &reference::State, sse: &State) {
+        let mut output1 = [0u8; 64];
+        let mut output2 = [0u8; 64];
+        sse.output_bytes(&mut output1);
+        refere.output_bytes(&mut output2);
+
+        assert_eq!(&output1[0..], &output2[0..], "doing: {}", doing);
+    }
+
+    #[test]
+    pub fn test_same_ref() {
+        let key = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15];
+        let nonce = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15];
+
+        let st_initial = State::init(&key, &nonce);
+        let r_initial = reference::State::init(&key, &nonce);
+
+        let mut st = st_initial.clone();
+        let mut r = r_initial.clone();
+
+        assert_state_equivalent("init", &r, &st);
+
+        st.round20();
+        r.round20();
+
+        assert_state_equivalent("round", &r, &st);
+
+        st.add_back(&st_initial);
+        r.add_back(&r_initial);
+
+        assert_state_equivalent("add_back", &r, &st);
+
+        st.increment();
+        r.increment();
+
+        assert_state_equivalent("increment", &r, &st);
+    }
+    */
+}

--- a/src/chacha20.rs
+++ b/src/chacha20.rs
@@ -14,7 +14,7 @@
 use core::cmp;
 
 use buffer::{BufferResult, RefReadBuffer, RefWriteBuffer};
-use cryptoutil::{read_u32_le, symm_enc_or_dec, write_u32_le, xor_keystream, xor_keystream_mut};
+use cryptoutil::{read_u32_le, symm_enc_or_dec, write_u32v_le, xor_keystream, xor_keystream_mut};
 use simd::u32x4;
 use symmetriccipher::{Decryptor, Encryptor, SymmetricCipherError, SynchronousStreamCipher};
 
@@ -54,9 +54,7 @@ macro_rules! state_to_buffer {
         let lens = [
             a1, a2, a3, a4, b1, b2, b3, b4, c1, c2, c3, c4, d1, d2, d3, d4,
         ];
-        for i in 0..lens.len() {
-            write_u32_le(&mut $output[i * 4..(i + 1) * 4], lens[i]);
-        }
+        write_u32v_le(&mut $output, &lens)
     }};
 }
 
@@ -88,6 +86,129 @@ static S12: u32x4 = u32x4(12, 12, 12, 12);
 static S8: u32x4 = u32x4(8, 8, 8, 8);
 static S7: u32x4 = u32x4(7, 7, 7, 7);
 
+impl ChaChaState {
+    // state initialization constant le-32bit array of b"expand 16-byte k"
+    const CST16: [u32; 4] = [0x61707865, 0x3120646e, 0x79622d36, 0x6b206574];
+    // state initialization constant le-32bit array of b"expand 32-byte k"
+    const CST32: [u32; 4] = [0x61707865, 0x3320646e, 0x79622d32, 0x6b206574];
+
+    // state is initialized to the following 32 bits elements:
+    // C1 C2 C3 C4
+    // K1 K2 K3 K4
+    // K1 K2 K3 K4 (16 bytes key) or K5 K6 K7 K8 (32 bytes keys)
+    // N1 N2 N3 N4 (16 bytes nonce) or 0 N1 N2 N3 (12 bytes nonce) or 0 0 N1 N2 (8 bytes nonce)
+
+    /// Initialize the state with key and nonce
+    pub(crate) fn init(key: &[u8], nonce: &[u8]) -> ChaChaState {
+        let (a, b, c) = match key.len() {
+            16 => Self::init_key16(key),
+            32 => Self::init_key32(key),
+            _ => unreachable!(),
+        };
+        let d = Self::init_nonce(nonce);
+        ChaChaState { a, b, c, d }
+    }
+
+    #[inline]
+    fn init_key16(key: &[u8]) -> (u32x4, u32x4, u32x4) {
+        let constant: &[u32; 4] = &Self::CST16;
+        let c = u32x4(constant[0], constant[1], constant[2], constant[3]);
+        let k1 = u32x4(
+            read_u32_le(&key[0..4]),
+            read_u32_le(&key[4..8]),
+            read_u32_le(&key[8..12]),
+            read_u32_le(&key[12..16]),
+        );
+        (c, k1, k1)
+    }
+
+    #[inline]
+    fn init_key32(key: &[u8]) -> (u32x4, u32x4, u32x4) {
+        let constant: &[u32; 4] = &Self::CST32;
+        let c = u32x4(constant[0], constant[1], constant[2], constant[3]);
+        let k1 = u32x4(
+            read_u32_le(&key[0..4]),
+            read_u32_le(&key[4..8]),
+            read_u32_le(&key[8..12]),
+            read_u32_le(&key[12..16]),
+        );
+        let k2 = u32x4(
+            read_u32_le(&key[16..20]),
+            read_u32_le(&key[20..24]),
+            read_u32_le(&key[24..28]),
+            read_u32_le(&key[28..32]),
+        );
+        (c, k1, k2)
+    }
+
+    #[inline]
+    fn init_nonce(nonce: &[u8]) -> u32x4 {
+        if nonce.len() == 16 {
+            u32x4(
+                read_u32_le(&nonce[0..4]),
+                read_u32_le(&nonce[4..8]),
+                read_u32_le(&nonce[8..12]),
+                read_u32_le(&nonce[12..16]),
+            )
+        } else if nonce.len() == 12 {
+            u32x4(
+                0,
+                read_u32_le(&nonce[0..4]),
+                read_u32_le(&nonce[4..8]),
+                read_u32_le(&nonce[8..12]),
+            )
+        } else {
+            u32x4(0, 0, read_u32_le(&nonce[0..4]), read_u32_le(&nonce[4..8]))
+        }
+    }
+
+    #[inline]
+    pub(crate) fn round20(&mut self) {
+        for _ in 0..10 {
+            round!(self);
+            swizzle!(self.b, self.c, self.d);
+            round!(self);
+            swizzle!(self.d, self.c, self.b);
+        }
+    }
+
+    #[inline]
+    #[allow(dead_code)]
+    pub(crate) fn round12(&mut self) {
+        for _ in 0..8 {
+            round!(self);
+            swizzle!(self.b, self.c, self.d);
+            round!(self);
+            swizzle!(self.d, self.c, self.b);
+        }
+    }
+
+    #[inline]
+    #[allow(dead_code)]
+    pub(crate) fn round8(&mut self) {
+        for _ in 0..4 {
+            round!(self);
+            swizzle!(self.b, self.c, self.d);
+            round!(self);
+            swizzle!(self.d, self.c, self.b);
+        }
+    }
+
+    #[inline]
+    pub(crate) fn increment(&mut self) {
+        self.d = self.d + u32x4(1, 0, 0, 0);
+    }
+
+    #[inline]
+    /// Add back the initial state
+    fn add_back(&mut self, initial: &Self) {
+        self.a = self.a + initial.a;
+        self.b = self.b + initial.b;
+        self.c = self.c + initial.c;
+        self.d = self.d + initial.d;
+    }
+}
+
 impl ChaCha20 {
     /// Create a new ChaCha20 context.
     ///
@@ -98,7 +219,7 @@ impl ChaCha20 {
         assert!(nonce.len() == 8 || nonce.len() == 12);
 
         ChaCha20 {
-            state: ChaCha20::expand(key, nonce),
+            state: ChaChaState::init(key, nonce),
             output: [0u8; 64],
             offset: 64,
         }
@@ -118,7 +239,7 @@ impl ChaCha20 {
         //  * (x4, x5, ... x11) is a 256 bit key.
         //  * (x12, x13, x14, x15) is a 128 bit nonce.
         let mut xchacha20 = ChaCha20 {
-            state: ChaCha20::expand(key, &nonce[0..16]),
+            state: ChaChaState::init(key, &nonce[0..16]),
             output: [0u8; 64],
             offset: 64,
         };
@@ -127,63 +248,12 @@ impl ChaCha20 {
         // with the subkey and the remaining 8 bytes of the nonce.
         let mut new_key = [0; 32];
         xchacha20.hchacha20(&mut new_key);
-        xchacha20.state = ChaCha20::expand(&new_key, &nonce[16..24]);
+        xchacha20.state = ChaChaState::init(&new_key, &nonce[16..24]);
 
         xchacha20
     }
 
-    fn expand(key: &[u8], nonce: &[u8]) -> ChaChaState {
-        let constant = match key.len() {
-            16 => b"expand 16-byte k",
-            32 => b"expand 32-byte k",
-            _ => unreachable!(),
-        };
-        let a = u32x4(
-            read_u32_le(&constant[0..4]),
-            read_u32_le(&constant[4..8]),
-            read_u32_le(&constant[8..12]),
-            read_u32_le(&constant[12..16]),
-        );
-        let b = u32x4(
-            read_u32_le(&key[0..4]),
-            read_u32_le(&key[4..8]),
-            read_u32_le(&key[8..12]),
-            read_u32_le(&key[12..16]),
-        );
-        ChaChaState {
-            a: a,
-            b: b,
-            c: if key.len() == 16 {
-                b
-            } else {
-                u32x4(
-                    read_u32_le(&key[16..20]),
-                    read_u32_le(&key[20..24]),
-                    read_u32_le(&key[24..28]),
-                    read_u32_le(&key[28..32]),
-                )
-            },
-            d: if nonce.len() == 16 {
-                u32x4(
-                    read_u32_le(&nonce[0..4]),
-                    read_u32_le(&nonce[4..8]),
-                    read_u32_le(&nonce[8..12]),
-                    read_u32_le(&nonce[12..16]),
-                )
-            } else if nonce.len() == 12 {
-                u32x4(
-                    0,
-                    read_u32_le(&nonce[0..4]),
-                    read_u32_le(&nonce[4..8]),
-                    read_u32_le(&nonce[8..12]),
-                )
-            } else {
-                u32x4(0, 0, read_u32_le(&nonce[0..4]), read_u32_le(&nonce[4..8]))
-            },
-        }
-    }
-
-    fn hchacha20(&mut self, out: &mut [u8]) {
+    fn hchacha20(&mut self, out: &mut [u8; 32]) {
         let mut state = self.state.clone();
 
         // Apply r/2 iterations of the same "double-round" function,
@@ -211,29 +281,18 @@ impl ChaCha20 {
         let u32x4(a1, a2, a3, a4) = state.a;
         let u32x4(d1, d2, d3, d4) = state.d;
         let lens = [a1, a2, a3, a4, d1, d2, d3, d4];
-        for i in 0..lens.len() {
-            write_u32_le(&mut out[i * 4..(i + 1) * 4], lens[i]);
-        }
+        write_u32v_le(&mut out[..], &lens[..]);
     }
 
     // put the the next 64 keystream bytes into self.output
     fn update(&mut self) {
         let mut state = self.state.clone();
-
-        for _ in 0..10 {
-            round!(state);
-            swizzle!(state.b, state.c, state.d);
-            round!(state);
-            swizzle!(state.d, state.c, state.b);
-        }
-        state.a = state.a + self.state.a;
-        state.b = state.b + self.state.b;
-        state.c = state.c + self.state.c;
-        state.d = state.d + self.state.d;
+        state.round20();
+        state.add_back(&self.state);
 
         state_to_buffer!(state, self.output);
 
-        self.state.d = self.state.d + u32x4(1, 0, 0, 0);
+        self.state.increment();
         let u32x4(c12, _, _, _) = self.state.d;
         if c12 == 0 {
             // we could increment the other counter word with an 8 byte nonce

--- a/src/chacha20.rs
+++ b/src/chacha20.rs
@@ -13,18 +13,10 @@
 // except according to those terms.
 use core::cmp;
 
+use crate::chacha::ChaChaEngine as ChaChaState;
 use buffer::{BufferResult, RefReadBuffer, RefWriteBuffer};
-use cryptoutil::{read_u32_le, symm_enc_or_dec, write_u32v_le, xor_keystream, xor_keystream_mut};
-use simd::u32x4;
+use cryptoutil::{symm_enc_or_dec, xor_keystream, xor_keystream_mut};
 use symmetriccipher::{Decryptor, Encryptor, SymmetricCipherError, SynchronousStreamCipher};
-
-#[derive(Clone)]
-struct ChaChaState {
-    a: u32x4,
-    b: u32x4,
-    c: u32x4,
-    d: u32x4,
-}
 
 /// ChaCha Context
 #[derive(Clone)]
@@ -32,181 +24,6 @@ pub struct ChaCha20 {
     state: ChaChaState,
     output: [u8; 64],
     offset: usize,
-}
-
-macro_rules! swizzle {
-    ($b: expr, $c: expr, $d: expr) => {{
-        let u32x4(b10, b11, b12, b13) = $b;
-        $b = u32x4(b11, b12, b13, b10);
-        let u32x4(c10, c11, c12, c13) = $c;
-        $c = u32x4(c12, c13, c10, c11);
-        let u32x4(d10, d11, d12, d13) = $d;
-        $d = u32x4(d13, d10, d11, d12);
-    }};
-}
-
-macro_rules! state_to_buffer {
-    ($state: expr, $output: expr) => {{
-        let u32x4(a1, a2, a3, a4) = $state.a;
-        let u32x4(b1, b2, b3, b4) = $state.b;
-        let u32x4(c1, c2, c3, c4) = $state.c;
-        let u32x4(d1, d2, d3, d4) = $state.d;
-        let lens = [
-            a1, a2, a3, a4, b1, b2, b3, b4, c1, c2, c3, c4, d1, d2, d3, d4,
-        ];
-        write_u32v_le(&mut $output, &lens)
-    }};
-}
-
-macro_rules! round {
-    ($state: expr) => {{
-        $state.a = $state.a + $state.b;
-        rotate!($state.d, $state.a, S16);
-        $state.c = $state.c + $state.d;
-        rotate!($state.b, $state.c, S12);
-        $state.a = $state.a + $state.b;
-        rotate!($state.d, $state.a, S8);
-        $state.c = $state.c + $state.d;
-        rotate!($state.b, $state.c, S7);
-    }};
-}
-
-macro_rules! rotate {
-    ($a: expr, $b: expr, $c:expr) => {{
-        let v = $a ^ $b;
-        let r = S32 - $c;
-        let right = v >> r;
-        $a = (v << $c) ^ right
-    }};
-}
-
-static S32: u32x4 = u32x4(32, 32, 32, 32);
-static S16: u32x4 = u32x4(16, 16, 16, 16);
-static S12: u32x4 = u32x4(12, 12, 12, 12);
-static S8: u32x4 = u32x4(8, 8, 8, 8);
-static S7: u32x4 = u32x4(7, 7, 7, 7);
-
-impl ChaChaState {
-    // state initialization constant le-32bit array of b"expand 16-byte k"
-    const CST16: [u32; 4] = [0x61707865, 0x3120646e, 0x79622d36, 0x6b206574];
-    // state initialization constant le-32bit array of b"expand 32-byte k"
-    const CST32: [u32; 4] = [0x61707865, 0x3320646e, 0x79622d32, 0x6b206574];
-
-    // state is initialized to the following 32 bits elements:
-    // C1 C2 C3 C4
-    // K1 K2 K3 K4
-    // K1 K2 K3 K4 (16 bytes key) or K5 K6 K7 K8 (32 bytes keys)
-    // N1 N2 N3 N4 (16 bytes nonce) or 0 N1 N2 N3 (12 bytes nonce) or 0 0 N1 N2 (8 bytes nonce)
-
-    /// Initialize the state with key and nonce
-    pub(crate) fn init(key: &[u8], nonce: &[u8]) -> ChaChaState {
-        let (a, b, c) = match key.len() {
-            16 => Self::init_key16(key),
-            32 => Self::init_key32(key),
-            _ => unreachable!(),
-        };
-        let d = Self::init_nonce(nonce);
-        ChaChaState { a, b, c, d }
-    }
-
-    #[inline]
-    fn init_key16(key: &[u8]) -> (u32x4, u32x4, u32x4) {
-        let constant: &[u32; 4] = &Self::CST16;
-        let c = u32x4(constant[0], constant[1], constant[2], constant[3]);
-        let k1 = u32x4(
-            read_u32_le(&key[0..4]),
-            read_u32_le(&key[4..8]),
-            read_u32_le(&key[8..12]),
-            read_u32_le(&key[12..16]),
-        );
-        (c, k1, k1)
-    }
-
-    #[inline]
-    fn init_key32(key: &[u8]) -> (u32x4, u32x4, u32x4) {
-        let constant: &[u32; 4] = &Self::CST32;
-        let c = u32x4(constant[0], constant[1], constant[2], constant[3]);
-        let k1 = u32x4(
-            read_u32_le(&key[0..4]),
-            read_u32_le(&key[4..8]),
-            read_u32_le(&key[8..12]),
-            read_u32_le(&key[12..16]),
-        );
-        let k2 = u32x4(
-            read_u32_le(&key[16..20]),
-            read_u32_le(&key[20..24]),
-            read_u32_le(&key[24..28]),
-            read_u32_le(&key[28..32]),
-        );
-        (c, k1, k2)
-    }
-
-    #[inline]
-    fn init_nonce(nonce: &[u8]) -> u32x4 {
-        if nonce.len() == 16 {
-            u32x4(
-                read_u32_le(&nonce[0..4]),
-                read_u32_le(&nonce[4..8]),
-                read_u32_le(&nonce[8..12]),
-                read_u32_le(&nonce[12..16]),
-            )
-        } else if nonce.len() == 12 {
-            u32x4(
-                0,
-                read_u32_le(&nonce[0..4]),
-                read_u32_le(&nonce[4..8]),
-                read_u32_le(&nonce[8..12]),
-            )
-        } else {
-            u32x4(0, 0, read_u32_le(&nonce[0..4]), read_u32_le(&nonce[4..8]))
-        }
-    }
-
-    #[inline]
-    pub(crate) fn round20(&mut self) {
-        for _ in 0..10 {
-            round!(self);
-            swizzle!(self.b, self.c, self.d);
-            round!(self);
-            swizzle!(self.d, self.c, self.b);
-        }
-    }
-
-    #[inline]
-    #[allow(dead_code)]
-    pub(crate) fn round12(&mut self) {
-        for _ in 0..8 {
-            round!(self);
-            swizzle!(self.b, self.c, self.d);
-            round!(self);
-            swizzle!(self.d, self.c, self.b);
-        }
-    }
-
-    #[inline]
-    #[allow(dead_code)]
-    pub(crate) fn round8(&mut self) {
-        for _ in 0..4 {
-            round!(self);
-            swizzle!(self.b, self.c, self.d);
-            round!(self);
-            swizzle!(self.d, self.c, self.b);
-        }
-    }
-
-    #[inline]
-    pub(crate) fn increment(&mut self) {
-        self.d = self.d + u32x4(1, 0, 0, 0);
-    }
-
-    #[inline]
-    /// Add back the initial state
-    fn add_back(&mut self, initial: &Self) {
-        self.a = self.a + initial.a;
-        self.b = self.b + initial.b;
-        self.c = self.c + initial.c;
-        self.d = self.d + initial.d;
-    }
 }
 
 impl ChaCha20 {
@@ -258,30 +75,12 @@ impl ChaCha20 {
 
         // Apply r/2 iterations of the same "double-round" function,
         // obtaining (z0, z1, ... z15) = doubleround r/2 (x0, x1, ... x15).
-        for _ in 0..10 {
-            round!(state);
-            let u32x4(b10, b11, b12, b13) = state.b;
-            state.b = u32x4(b11, b12, b13, b10);
-            let u32x4(c10, c11, c12, c13) = state.c;
-            state.c = u32x4(c12, c13, c10, c11);
-            let u32x4(d10, d11, d12, d13) = state.d;
-            state.d = u32x4(d13, d10, d11, d12);
-            round!(state);
-            let u32x4(b20, b21, b22, b23) = state.b;
-            state.b = u32x4(b23, b20, b21, b22);
-            let u32x4(c20, c21, c22, c23) = state.c;
-            state.c = u32x4(c22, c23, c20, c21);
-            let u32x4(d20, d21, d22, d23) = state.d;
-            state.d = u32x4(d21, d22, d23, d20);
-        }
+        state.round20();
 
         // HChaCha20 then outputs the 256-bit block (z0, z1, z2, z3, z12, z13,
         // z14, z15).  These correspond to the constant and input positions in
         // the ChaCha matrix.
-        let u32x4(a1, a2, a3, a4) = state.a;
-        let u32x4(d1, d2, d3, d4) = state.d;
-        let lens = [a1, a2, a3, a4, d1, d2, d3, d4];
-        write_u32v_le(&mut out[..], &lens[..]);
+        state.output_ad_bytes(out)
     }
 
     // put the the next 64 keystream bytes into self.output
@@ -290,17 +89,9 @@ impl ChaCha20 {
         state.round20();
         state.add_back(&self.state);
 
-        state_to_buffer!(state, self.output);
+        state.output_bytes(&mut self.output);
 
         self.state.increment();
-        let u32x4(c12, _, _, _) = self.state.d;
-        if c12 == 0 {
-            // we could increment the other counter word with an 8 byte nonce
-            // but other implementations like boringssl have this same
-            // limitation
-            panic!("counter is exhausted");
-        }
-
         self.offset = 0;
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,6 +53,9 @@ pub mod blake2b;
 pub mod blake2s;
 
 #[cfg(feature = "chacha")]
+pub mod chacha;
+
+#[cfg(feature = "chacha")]
 pub mod chacha20;
 
 #[cfg(all(feature = "chacha", feature = "poly1305"))]


### PR DESCRIPTION
separate the chacha engine

* cleanup the engine
* separate from the cipher bits
* also implement a x86 SSE backend (with a modest 1.5x speedup over the reference implementation)