### PR TITLE
Remove the inline attribute from swizzle macro

### DIFF
--- a/src/chacha/sse2.rs
+++ b/src/chacha/sse2.rs
@@ -35,7 +35,6 @@ impl Align128 {
     }
 }
 
-#[inline]
 macro_rules! swizzle {
     ($b: expr, $c: expr, $d: expr) => {
         $b = _mm_shuffle_epi32($b, 0b00111001); // <<< 8


### PR DESCRIPTION
Using `#[inline]` on top of `macro_rules!` is pointless and results into
an error on the latest nightly compiler.