### PR TITLE
use const generic to define FixedBuffer

### DIFF
--- a/src/cryptoutil.rs
+++ b/src/cryptoutil.rs
@@ -152,185 +152,98 @@ pub fn zero(dst: &mut [u8]) {
     }
 }
 
-/// A `FixedBuffer`, likes its name implies, is a fixed size buffer. When the buffer becomes full, it
-/// must be processed. The `input()` method takes care of processing and then clearing the buffer
-/// automatically. However, other methods do not and require the caller to process the buffer. Any
-/// method that modifies the buffer directory or provides the caller with bytes that can be modifies
-/// results in those bytes being marked as used by the buffer.
-pub trait FixedBuffer {
-    /// Input a vector of bytes. If the buffer becomes full, process it with the provided
-    /// function and then clear the buffer.
-    fn input<F: FnMut(&[u8])>(&mut self, input: &[u8], func: F);
-
-    /// Reset the buffer.
-    fn reset(&mut self);
-
-    /// Zero the buffer up until the specified index. The buffer position currently must not be
-    /// greater than that index.
-    fn zero_until(&mut self, idx: usize);
-
-    /// Get a slice of the buffer of the specified size. There must be at least that many bytes
-    /// remaining in the buffer.
-    fn next(&mut self, len: usize) -> &mut [u8];
-
-    /// Get the current buffer. The buffer must already be full. This clears the buffer as well.
-    fn full_buffer(&mut self) -> &[u8];
-
-    /// Get the current buffer.
-    fn current_buffer(&mut self) -> &[u8];
-
-    /// Get the current position of the buffer.
-    fn position(&self) -> usize;
-
-    /// Get the number of bytes remaining in the buffer until it is full.
-    fn remaining(&self) -> usize;
-
-    /// Get the size of the buffer
-    fn size(&self) -> usize;
-}
-
-macro_rules! impl_fixed_buffer( ($name:ident, $size:expr, $shift:expr) => (
-    impl FixedBuffer for $name {
-        fn input<F: FnMut(&[u8])>(&mut self, input: &[u8], mut func: F) {
-            let mut i = 0;
-
-            // FIXME: #6304 - This local variable shouldn't be necessary.
-            let size = $size;
-
-            // If there is already data in the buffer, copy as much as we can into it and process
-            // the data if the buffer becomes full.
-            if self.buffer_idx != 0 {
-                let buffer_remaining = size - self.buffer_idx;
-                if input.len() >= buffer_remaining {
-                        copy_memory(
-                            &input[..buffer_remaining],
-                            &mut self.buffer[self.buffer_idx..size]);
-                    self.buffer_idx = 0;
-                    func(&self.buffer);
-                    i += buffer_remaining;
-                } else {
-                    copy_memory(
-                        input,
-                        &mut self.buffer[self.buffer_idx..self.buffer_idx + input.len()]);
-                    self.buffer_idx += input.len();
-                    return;
-                }
-            }
-
-            // While we have at least a full buffer size chunks's worth of data, process that data
-            // without copying it into the buffer
-            if input.len() - i >= size {
-                let remaining = input.len() - i;
-                let block_bytes = (remaining >> $shift) << $shift;
-                func(&input[i..i + block_bytes]);
-                i += block_bytes;
-            }
-
-            // Copy any input data into the buffer. At this point in the method, the ammount of
-            // data left in the input vector will be less than the buffer size and the buffer will
-            // be empty.
-            let input_remaining = input.len() - i;
-            copy_memory(
-                &input[i..],
-                &mut self.buffer[0..input_remaining]);
-            self.buffer_idx += input_remaining;
-        }
-
-        fn reset(&mut self) {
-            self.buffer_idx = 0;
-        }
-
-        fn zero_until(&mut self, idx: usize) {
-            assert!(idx >= self.buffer_idx);
-            zero(&mut self.buffer[self.buffer_idx..idx]);
-            self.buffer_idx = idx;
-        }
-
-        fn next(&mut self, len: usize) -> &mut [u8] {
-            self.buffer_idx += len;
-            &mut self.buffer[self.buffer_idx - len..self.buffer_idx]
-        }
-
-        fn full_buffer(&mut self) -> &[u8] {
-            assert!(self.buffer_idx == $size);
-            self.buffer_idx = 0;
-            &self.buffer[..$size]
-        }
-
-        fn current_buffer(&mut self) -> &[u8] {
-            let tmp = self.buffer_idx;
-            self.buffer_idx = 0;
-            &self.buffer[..tmp]
-        }
-
-        fn position(&self) -> usize { self.buffer_idx }
-
-        fn remaining(&self) -> usize { $size - self.buffer_idx }
-
-        fn size(&self) -> usize { $size }
-    }
-));
-
-/// A fixed size buffer of 64 bytes useful for cryptographic operations.
+/// A fixed size buffer of N bytes useful for cryptographic operations.
 #[derive(Clone)]
-pub struct FixedBuffer64 {
-    buffer: [u8; 64],
+pub(crate) struct FixedBuffer<const N: usize> {
+    buffer: [u8; N],
     buffer_idx: usize,
 }
 
-impl FixedBuffer64 {
+impl<const N: usize> FixedBuffer<N> {
     /// Create a new buffer
-    pub fn new() -> FixedBuffer64 {
-        FixedBuffer64 {
-            buffer: [0u8; 64],
+    pub fn new() -> Self {
+        Self {
+            buffer: [0u8; N],
             buffer_idx: 0,
         }
     }
-}
 
-impl_fixed_buffer!(FixedBuffer64, 64, 6);
+    pub fn input<F: FnMut(&[u8])>(&mut self, input: &[u8], mut func: F) {
+        let mut i = 0;
 
-/// A fixed size buffer of 128 bytes useful for cryptographic operations.
-#[derive(Clone)]
-pub struct FixedBuffer128 {
-    buffer: [u8; 128],
-    buffer_idx: usize,
-}
-
-impl FixedBuffer128 {
-    /// Create a new buffer
-    pub fn new() -> FixedBuffer128 {
-        FixedBuffer128 {
-            buffer: [0u8; 128],
-            buffer_idx: 0,
+        // If there is already data in the buffer, copy as much as we can into it and process
+        // the data if the buffer becomes full.
+        if self.buffer_idx != 0 {
+            let buffer_remaining = N - self.buffer_idx;
+            if input.len() >= buffer_remaining {
+                copy_memory(
+                    &input[..buffer_remaining],
+                    &mut self.buffer[self.buffer_idx..N],
+                );
+                self.buffer_idx = 0;
+                func(&self.buffer);
+                i += buffer_remaining;
+            } else {
+                copy_memory(
+                    input,
+                    &mut self.buffer[self.buffer_idx..self.buffer_idx + input.len()],
+                );
+                self.buffer_idx += input.len();
+                return;
+            }
         }
+
+        // While we have at least a full buffer size chunks's worth of data, process that data
+        // without copying it into the buffer
+        if input.len() - i >= N {
+            let remaining = input.len() - i;
+            let block_bytes = (remaining / N) * N;
+            func(&input[i..i + block_bytes]);
+            i += block_bytes;
+        }
+
+        // Copy any input data into the buffer. At this point in the method, the ammount of
+        // data left in the input vector will be less than the buffer size and the buffer will
+        // be empty.
+        let input_remaining = input.len() - i;
+        copy_memory(&input[i..], &mut self.buffer[0..input_remaining]);
+        self.buffer_idx += input_remaining;
     }
-}
 
-impl_fixed_buffer!(FixedBuffer128, 128, 7);
+    pub fn reset(&mut self) {
+        self.buffer_idx = 0;
+    }
 
-/// The `StandardPadding` trait adds a method useful for various hash algorithms to a `FixedBuffer`
-/// struct.
-pub trait StandardPadding {
+    fn zero_until(&mut self, idx: usize) {
+        assert!(idx >= self.buffer_idx);
+        zero(&mut self.buffer[self.buffer_idx..idx]);
+        self.buffer_idx = idx;
+    }
+
+    pub fn next(&mut self, len: usize) -> &mut [u8] {
+        self.buffer_idx += len;
+        &mut self.buffer[self.buffer_idx - len..self.buffer_idx]
+    }
+
+    pub fn full_buffer(&mut self) -> &[u8; N] {
+        assert!(self.buffer_idx == N);
+        self.buffer_idx = 0;
+        &self.buffer
+    }
+
     /// Add standard padding to the buffer. The buffer must not be full when this method is called
     /// and is guaranteed to have exactly rem remaining bytes when it returns. If there are not at
     /// least rem bytes available, the buffer will be zero padded, processed, cleared, and then
     /// filled with zeros again until only rem bytes are remaining.
-    fn standard_padding<F: FnMut(&[u8])>(&mut self, rem: usize, func: F);
-}
-
-impl<T: FixedBuffer> StandardPadding for T {
-    fn standard_padding<F: FnMut(&[u8])>(&mut self, rem: usize, mut func: F) {
-        let size = self.size();
-
+    pub fn standard_padding<F: FnMut(&[u8; N])>(&mut self, rem: usize, mut func: F) {
         self.next(1)[0] = 128;
 
-        if self.remaining() < rem {
-            self.zero_until(size);
+        if (N - self.buffer_idx) < rem {
+            self.zero_until(N);
             func(self.full_buffer());
         }
 
-        self.zero_until(size - rem);
+        self.zero_until(N - rem);
     }
 }
 

--- a/src/sha1.rs
+++ b/src/sha1.rs
@@ -13,7 +13,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use crate::cryptoutil::{read_u32v_be, write_u32_be, FixedBuffer, FixedBuffer64, StandardPadding};
+use crate::cryptoutil::{read_u32v_be, write_u32_be, FixedBuffer};
 use crate::digest::Digest;
 use crate::simd::u32x4;
 
@@ -353,7 +353,7 @@ fn add_input(st: &mut Sha1, msg: &[u8]) {
     // Assumes that msg.len() can be converted to u64 without overflow
     st.length_bits = add_bytes_to_bits(st.length_bits, msg.len() as u64);
     let st_h = &mut st.h;
-    st.buffer.input(msg, |d: &[u8]| {
+    st.buffer.input(msg, |d| {
         sha1_digest_block(st_h, d);
     });
 }
@@ -362,7 +362,7 @@ fn mk_result(st: &mut Sha1, rs: &mut [u8]) {
     if !st.computed {
         let st_h = &mut st.h;
         st.buffer
-            .standard_padding(8, |d: &[u8]| sha1_digest_block(&mut *st_h, d));
+            .standard_padding(8, |d| sha1_digest_block(&mut *st_h, d));
         write_u32_be(st.buffer.next(4), (st.length_bits >> 32) as u32);
         write_u32_be(st.buffer.next(4), st.length_bits as u32);
         sha1_digest_block(st_h, st.buffer.full_buffer());
@@ -382,7 +382,7 @@ fn mk_result(st: &mut Sha1, rs: &mut [u8]) {
 pub struct Sha1 {
     h: [u32; STATE_LEN],
     length_bits: u64,
-    buffer: FixedBuffer64,
+    buffer: FixedBuffer<64>,
     computed: bool,
 }
 
@@ -392,7 +392,7 @@ impl Sha1 {
         let mut st = Sha1 {
             h: [0u32; STATE_LEN],
             length_bits: 0u64,
-            buffer: FixedBuffer64::new(),
+            buffer: FixedBuffer::new(),
             computed: false,
         };
         st.reset();


### PR DESCRIPTION
replace FixedBuffer trait, generating macro and specific instanciations
of FixedBuffer at 64 and 128 bytes, by a const generic version.