### PR TITLE
Revert the curve25519 public API hidden by release 0.3.4

### DIFF
--- a/src/curve25519.rs
+++ b/src/curve25519.rs
@@ -39,7 +39,7 @@ Bounds on each t[i] vary depending on context.
 */
 
 #[derive(Clone)]
-pub(crate) struct Fe(pub [i32; 10]);
+pub struct Fe(pub [i32; 10]);
 
 impl PartialEq for Fe {
     fn eq(&self, other: &Fe) -> bool {
@@ -453,7 +453,7 @@ impl Mul for &Fe {
 
 impl Fe {
     #[rustfmt::skip]
-    pub(crate) fn from_bytes(s: &[u8]) -> Fe {
+    pub fn from_bytes(s: &[u8]) -> Fe {
         let mut h0 = load_4i(&s[0..4]);
         let mut h1 = load_3i(&s[4..7]) << 6;
         let mut h2 = load_3i(&s[7..10]) << 5;
@@ -507,7 +507,7 @@ impl Fe {
     */
 
     #[rustfmt::skip]
-    pub(crate) fn to_bytes(&self) -> [u8; 32] {
+    pub fn to_bytes(&self) -> [u8; 32] {
         let &Fe(es) = self;
         let mut h0 = es[0];
         let mut h1 = es[1];
@@ -591,7 +591,7 @@ impl Fe {
         ]
     }
 
-    pub(crate) fn maybe_swap_with(&mut self, other: &mut Fe, do_swap: i32) {
+    pub fn maybe_swap_with(&mut self, other: &mut Fe, do_swap: i32) {
         let &mut Fe(f) = self;
         let &mut Fe(g) = other;
         let f0 = f[0];
@@ -661,7 +661,7 @@ impl Fe {
         ]);
     }
 
-    pub(crate) fn maybe_set(&mut self, other: &Fe, do_swap: i32) {
+    pub fn maybe_set(&mut self, other: &Fe, do_swap: i32) {
         let &mut Fe(f) = self;
         let &Fe(g) = other;
         let f0 = f[0];
@@ -1028,7 +1028,7 @@ impl Fe {
             h5 as i32, h6 as i32, h7 as i32, h8 as i32, h9 as i32])
     }
 
-    pub(crate) fn invert(&self) -> Fe {
+    pub fn invert(&self) -> Fe {
         let z1 = self.clone();
 
         /* qhasm: z2 = z1^2^1 */
@@ -1148,22 +1148,14 @@ impl Fe {
 }
 
 #[derive(Clone)]
-pub(crate) struct GeP2 {
+pub struct GeP2 {
     x: Fe,
     y: Fe,
     z: Fe,
 }
 
 #[derive(Clone)]
-pub(crate) struct GeP3 {
-    x: Fe,
-    y: Fe,
-    z: Fe,
-    t: Fe,
-}
-
-#[derive(Clone)]
-pub(crate) struct GeP1P1 {
+pub struct GeP3 {
     x: Fe,
     y: Fe,
     z: Fe,
@@ -1171,14 +1163,22 @@ pub(crate) struct GeP1P1 {
 }
 
 #[derive(Clone)]
-pub(crate) struct GePrecomp {
+pub struct GeP1P1 {
+    x: Fe,
+    y: Fe,
+    z: Fe,
+    t: Fe,
+}
+
+#[derive(Clone)]
+pub struct GePrecomp {
     y_plus_x: Fe,
     y_minus_x: Fe,
     xy2d: Fe,
 }
 
 #[derive(Clone)]
-pub(crate) struct GeCached {
+pub struct GeCached {
     y_plus_x: Fe,
     y_minus_x: Fe,
     z: Fe,
@@ -1186,7 +1186,7 @@ pub(crate) struct GeCached {
 }
 
 impl GeP1P1 {
-    pub(crate) fn to_p2(&self) -> GeP2 {
+    pub fn to_p2(&self) -> GeP2 {
         GeP2 {
             x: &self.x * &self.t,
             y: &self.y * &self.z,
@@ -1213,7 +1213,7 @@ impl GeP2 {
         }
     }
 
-    pub(crate) fn to_bytes(&self) -> [u8; 32] {
+    pub fn to_bytes(&self) -> [u8; 32] {
         let recip = self.z.invert();
         let x = &self.x * &recip;
         let y = &self.y * &recip;
@@ -1280,11 +1280,7 @@ impl GeP2 {
     and b = b[0]+256*b[1]+...+256^31 b[31].
     B is the Ed25519 base point (x,4/5) with x positive.
     */
-    pub(crate) fn double_scalarmult_vartime(
-        a_scalar: &[u8],
-        a_point: GeP3,
-        b_scalar: &[u8],
-    ) -> GeP2 {
+    pub fn double_scalarmult_vartime(a_scalar: &[u8], a_point: GeP3, b_scalar: &[u8]) -> GeP2 {
         let aslide = GeP2::slide(a_scalar);
         let bslide = GeP2::slide(b_scalar);
 
@@ -1338,7 +1334,7 @@ impl GeP2 {
 }
 
 impl GeP3 {
-    pub(crate) fn from_bytes_negate_vartime(s: &[u8]) -> Option<GeP3> {
+    pub fn from_bytes_negate_vartime(s: &[u8]) -> Option<GeP3> {
         let y = Fe::from_bytes(s);
         let z = FE_ONE.clone();
         let y_squared = y.square();
@@ -1382,7 +1378,7 @@ impl GeP3 {
         }
     }
 
-    pub(crate) fn to_cached(&self) -> GeCached {
+    pub fn to_cached(&self) -> GeCached {
         GeCached {
             y_plus_x: &self.y + &self.x,
             y_minus_x: &self.y - &self.x,
@@ -1404,7 +1400,7 @@ impl GeP3 {
         self.to_p2().dbl()
     }
 
-    pub(crate) fn to_bytes(&self) -> [u8; 32] {
+    pub fn to_bytes(&self) -> [u8; 32] {
         let recip = self.z.invert();
         let x = &self.x * &recip;
         let y = &self.y * &recip;
@@ -1564,13 +1560,13 @@ impl GePrecomp {
         }
     }
 
-    pub(crate) fn maybe_set(&mut self, other: &GePrecomp, do_swap: i32) {
+    pub fn maybe_set(&mut self, other: &GePrecomp, do_swap: i32) {
         self.y_plus_x.maybe_set(&other.y_plus_x, do_swap);
         self.y_minus_x.maybe_set(&other.y_minus_x, do_swap);
         self.xy2d.maybe_set(&other.xy2d, do_swap);
     }
 
-    pub(crate) fn select(pos: usize, b: i8) -> GePrecomp {
+    pub fn select(pos: usize, b: i8) -> GePrecomp {
         let bnegative = (b as u8) >> 7;
         let babs: u8 = (b - (((-(bnegative as i8)) & b) << 1)) as u8;
         let mut t = GePrecomp::zero();
@@ -1600,7 +1596,7 @@ B is the Ed25519 base point (x,4/5) with x positive.
 Preconditions:
   a[31] <= 127
 */
-pub(crate) fn ge_scalarmult_base(a: &[u8]) -> GeP3 {
+pub fn ge_scalarmult_base(a: &[u8]) -> GeP3 {
     let mut es: [i8; 64] = [0; 64];
     let mut r: GeP1P1;
     let mut s: GeP2;
@@ -1659,7 +1655,7 @@ Output:
     Overwrites s in place.
 */
 #[rustfmt::skip]
-pub(crate) fn sc_reduce(s: &mut [u8]) {
+pub fn sc_reduce(s: &mut [u8]) {
     let mut s0: i64 = 2097151 & load_3i(s);
     let mut s1: i64 = 2097151 & (load_4i(&s[2..6]) >> 5);
     let mut s2: i64 = 2097151 & (load_3i(&s[5..8]) >> 2);
@@ -1911,7 +1907,7 @@ Output:
     where l = 2^252 + 27742317777372353535851937790883648493.
 */
 #[rustfmt::skip]
-pub(crate) fn sc_muladd(s: &mut[u8], a: &[u8], b: &[u8], c: &[u8]) {
+pub fn sc_muladd(s: &mut[u8], a: &[u8], b: &[u8], c: &[u8]) {
     let a0 = 2097151 & load_3i(&a[0..3]);
     let a1 = 2097151 & (load_4i(&a[2..6]) >> 5);
     let a2 = 2097151 & (load_3i(&a[5..8]) >> 2);
@@ -2244,8 +2240,6 @@ pub(crate) fn sc_muladd(s: &mut[u8], a: &[u8], b: &[u8], c: &[u8]) {
     s[31] = (s11 >> 17) as u8;
 }
 
-/// Computes a shared secret from the curve25519 private key (n) and public
-/// key (p)
 pub fn curve25519(n: &[u8], p: &[u8]) -> [u8; 32] {
     let mut e = [0u8; 32];
     let mut x2;
@@ -2307,7 +2301,6 @@ pub fn curve25519(n: &[u8], p: &[u8]) -> [u8; 32] {
     (z2.invert() * x2).to_bytes()
 }
 
-/// Derives a public key from a private key
 pub fn curve25519_base(x: &[u8]) -> [u8; 32] {
     let mut base: [u8; 32] = [0; 32];
     base[0] = 9;


### PR DESCRIPTION
Some of it is used by `ed25519-bip32`.
Without a version bump to 0.4, the removal of names may break any dependencies like cryptoxide = "~0.3".