### PR TITLE
Revert 0.3 API breakage

### DIFF
--- a/src/curve25519.rs
+++ b/src/curve25519.rs
@@ -39,7 +39,8 @@ Bounds on each t[i] vary depending on context.
 */
 
 #[derive(Clone)]
-pub(crate) struct Fe(pub [i32; 10]);
+#[doc(hidden)]
+pub struct Fe(pub [i32; 10]);
 
 impl PartialEq for Fe {
     fn eq(&self, other: &Fe) -> bool {
@@ -452,8 +453,9 @@ impl Mul for &Fe {
 }
 
 impl Fe {
+    #[doc(hidden)]
     #[rustfmt::skip]
-    pub(crate) fn from_bytes(s: &[u8]) -> Fe {
+    pub fn from_bytes(s: &[u8]) -> Fe {
         let mut h0 = load_4i(&s[0..4]);
         let mut h1 = load_3i(&s[4..7]) << 6;
         let mut h2 = load_3i(&s[7..10]) << 5;
@@ -506,8 +508,9 @@ impl Fe {
       so floor(2^(-255)(h + 19 2^(-25) h9 + 2^(-1))) = q.
     */
 
+    #[doc(hidden)]
     #[rustfmt::skip]
-    pub(crate) fn to_bytes(&self) -> [u8; 32] {
+    pub fn to_bytes(&self) -> [u8; 32] {
         let &Fe(es) = self;
         let mut h0 = es[0];
         let mut h1 = es[1];
@@ -591,7 +594,8 @@ impl Fe {
         ]
     }
 
-    pub(crate) fn maybe_swap_with(&mut self, other: &mut Fe, do_swap: i32) {
+    #[doc(hidden)]
+    pub fn maybe_swap_with(&mut self, other: &mut Fe, do_swap: i32) {
         let &mut Fe(f) = self;
         let &mut Fe(g) = other;
         let f0 = f[0];
@@ -661,7 +665,8 @@ impl Fe {
         ]);
     }
 
-    pub(crate) fn maybe_set(&mut self, other: &Fe, do_swap: i32) {
+    #[doc(hidden)]
+    pub fn maybe_set(&mut self, other: &Fe, do_swap: i32) {
         let &mut Fe(f) = self;
         let &Fe(g) = other;
         let f0 = f[0];
@@ -1028,7 +1033,8 @@ impl Fe {
             h5 as i32, h6 as i32, h7 as i32, h8 as i32, h9 as i32])
     }
 
-    pub(crate) fn invert(&self) -> Fe {
+    #[doc(hidden)]
+    pub fn invert(&self) -> Fe {
         let z1 = self.clone();
 
         /* qhasm: z2 = z1^2^1 */
@@ -1148,7 +1154,8 @@ impl Fe {
 }
 
 #[derive(Clone)]
-pub(crate) struct GeP2 {
+#[doc(hidden)]
+pub struct GeP2 {
     x: Fe,
     y: Fe,
     z: Fe,
@@ -1164,7 +1171,8 @@ pub struct GeP3 {
 }
 
 #[derive(Clone)]
-pub(crate) struct GeP1P1 {
+#[doc(hidden)]
+pub struct GeP1P1 {
     x: Fe,
     y: Fe,
     z: Fe,
@@ -1172,14 +1180,16 @@ pub(crate) struct GeP1P1 {
 }
 
 #[derive(Clone)]
-pub(crate) struct GePrecomp {
+#[doc(hidden)]
+pub struct GePrecomp {
     y_plus_x: Fe,
     y_minus_x: Fe,
     xy2d: Fe,
 }
 
 #[derive(Clone)]
-pub(crate) struct GeCached {
+#[doc(hidden)]
+pub struct GeCached {
     y_plus_x: Fe,
     y_minus_x: Fe,
     z: Fe,
@@ -1187,7 +1197,8 @@ pub(crate) struct GeCached {
 }
 
 impl GeP1P1 {
-    pub(crate) fn to_p2(&self) -> GeP2 {
+    #[doc(hidden)]
+    pub fn to_p2(&self) -> GeP2 {
         GeP2 {
             x: &self.x * &self.t,
             y: &self.y * &self.z,
@@ -1214,7 +1225,8 @@ impl GeP2 {
         }
     }
 
-    pub(crate) fn to_bytes(&self) -> [u8; 32] {
+    #[doc(hidden)]
+    pub fn to_bytes(&self) -> [u8; 32] {
         let recip = self.z.invert();
         let x = &self.x * &recip;
         let y = &self.y * &recip;
@@ -1281,11 +1293,8 @@ impl GeP2 {
     and b = b[0]+256*b[1]+...+256^31 b[31].
     B is the Ed25519 base point (x,4/5) with x positive.
     */
-    pub(crate) fn double_scalarmult_vartime(
-        a_scalar: &[u8],
-        a_point: GeP3,
-        b_scalar: &[u8],
-    ) -> GeP2 {
+    #[doc(hidden)]
+    pub fn double_scalarmult_vartime(a_scalar: &[u8], a_point: GeP3, b_scalar: &[u8]) -> GeP2 {
         let aslide = GeP2::slide(a_scalar);
         let bslide = GeP2::slide(b_scalar);
 
@@ -1383,7 +1392,8 @@ impl GeP3 {
         }
     }
 
-    pub(crate) fn to_cached(&self) -> GeCached {
+    #[doc(hidden)]
+    pub fn to_cached(&self) -> GeCached {
         GeCached {
             y_plus_x: &self.y + &self.x,
             y_minus_x: &self.y - &self.x,
@@ -1405,7 +1415,8 @@ impl GeP3 {
         self.to_p2().dbl()
     }
 
-    pub(crate) fn to_bytes(&self) -> [u8; 32] {
+    #[doc(hidden)]
+    pub fn to_bytes(&self) -> [u8; 32] {
         let recip = self.z.invert();
         let x = &self.x * &recip;
         let y = &self.y * &recip;
@@ -1565,13 +1576,15 @@ impl GePrecomp {
         }
     }
 
-    pub(crate) fn maybe_set(&mut self, other: &GePrecomp, do_swap: i32) {
+    #[doc(hidden)]
+    pub fn maybe_set(&mut self, other: &GePrecomp, do_swap: i32) {
         self.y_plus_x.maybe_set(&other.y_plus_x, do_swap);
         self.y_minus_x.maybe_set(&other.y_minus_x, do_swap);
         self.xy2d.maybe_set(&other.xy2d, do_swap);
     }
 
-    pub(crate) fn select(pos: usize, b: i8) -> GePrecomp {
+    #[doc(hidden)]
+    pub fn select(pos: usize, b: i8) -> GePrecomp {
         let bnegative = (b as u8) >> 7;
         let babs: u8 = (b - (((-(bnegative as i8)) & b) << 1)) as u8;
         let mut t = GePrecomp::zero();
@@ -1660,8 +1673,9 @@ Output:
     where l = 2^252 + 27742317777372353535851937790883648493.
     Overwrites s in place.
 */
+#[doc(hidden)]
 #[rustfmt::skip]
-pub(crate) fn sc_reduce(s: &mut [u8]) {
+pub fn sc_reduce(s: &mut [u8]) {
     let mut s0: i64 = 2097151 & load_3i(s);
     let mut s1: i64 = 2097151 & (load_4i(&s[2..6]) >> 5);
     let mut s2: i64 = 2097151 & (load_3i(&s[5..8]) >> 2);
@@ -1912,8 +1926,9 @@ Output:
     s[0]+256*s[1]+...+256^31*s[31] = (ab+c) mod l
     where l = 2^252 + 27742317777372353535851937790883648493.
 */
+#[doc(hidden)]
 #[rustfmt::skip]
-pub(crate) fn sc_muladd(s: &mut[u8], a: &[u8], b: &[u8], c: &[u8]) {
+pub fn sc_muladd(s: &mut[u8], a: &[u8], b: &[u8], c: &[u8]) {
     let a0 = 2097151 & load_3i(&a[0..3]);
     let a1 = 2097151 & (load_4i(&a[2..6]) >> 5);
     let a2 = 2097151 & (load_3i(&a[5..8]) >> 2);
@@ -2246,8 +2261,6 @@ pub(crate) fn sc_muladd(s: &mut[u8], a: &[u8], b: &[u8], c: &[u8]) {
     s[31] = (s11 >> 17) as u8;
 }
 
-/// Computes a shared secret from the curve25519 private key (n) and public
-/// key (p)
 pub fn curve25519(n: &[u8], p: &[u8]) -> [u8; 32] {
     let mut e = [0u8; 32];
     let mut x2;
@@ -2309,7 +2322,6 @@ pub fn curve25519(n: &[u8], p: &[u8]) -> [u8; 32] {
     (z2.invert() * x2).to_bytes()
 }
 
-/// Derives a public key from a private key
 pub fn curve25519_base(x: &[u8]) -> [u8; 32] {
     let mut base: [u8; 32] = [0; 32];
     base[0] = 9;


### PR DESCRIPTION
Restores all public names hidden by commit 6a4713d5867fcee2d8489260ff063b57adac141a, but hides them from the docs.