### PR TITLE
Add support for other chacha and salsa rounds configuration

### DIFF
--- a/src/chacha/mod.rs
+++ b/src/chacha/mod.rs
@@ -8,7 +8,7 @@ mod reference;
     any(target_arch = "x86", target_arch = "x86_64"),
     any(target_feature = "sse2", target_feature = "avx2")
 )))]
-pub(crate) type ChaChaEngine = reference::State;
+pub(crate) type ChaChaEngine<const R: usize> = reference::State<R>;
 
 #[cfg(all(
     any(target_arch = "x86", target_arch = "x86_64"),
@@ -20,4 +20,4 @@ mod sse2;
     any(target_arch = "x86", target_arch = "x86_64"),
     target_feature = "sse2",
 ))]
-pub(crate) type ChaChaEngine = sse2::State;
+pub(crate) type ChaChaEngine<const R: usize> = sse2::State<R>;

--- a/src/chacha/reference.rs
+++ b/src/chacha/reference.rs
@@ -2,7 +2,7 @@ use crate::cryptoutil::{read_u32_le, write_u32v_le};
 use crate::simd::u32x4;
 
 #[derive(Clone)]
-pub(crate) struct State {
+pub(crate) struct State<const ROUNDS: usize> {
     a: u32x4,
     b: u32x4,
     c: u32x4,
@@ -62,7 +62,7 @@ static S12: u32x4 = u32x4(12, 12, 12, 12);
 static S8: u32x4 = u32x4(8, 8, 8, 8);
 static S7: u32x4 = u32x4(7, 7, 7, 7);
 
-impl State {
+impl<const ROUNDS: usize> State<ROUNDS> {
     // state initialization constant le-32bit array of b"expand 16-byte k"
     const CST16: [u32; 4] = [0x61707865, 0x3120646e, 0x79622d36, 0x6b206574];
     // state initialization constant le-32bit array of b"expand 32-byte k"
@@ -139,30 +139,8 @@ impl State {
     }
 
     #[inline]
-    pub(crate) fn round20(&mut self) {
-        for _ in 0..10 {
-            round!(self);
-            swizzle!(self.b, self.c, self.d);
-            round!(self);
-            swizzle!(self.d, self.c, self.b);
-        }
-    }
-
-    #[inline]
-    #[allow(dead_code)]
-    pub(crate) fn round12(&mut self) {
-        for _ in 0..8 {
-            round!(self);
-            swizzle!(self.b, self.c, self.d);
-            round!(self);
-            swizzle!(self.d, self.c, self.b);
-        }
-    }
-
-    #[inline]
-    #[allow(dead_code)]
-    pub(crate) fn round8(&mut self) {
-        for _ in 0..4 {
+    pub(crate) fn round(&mut self) {
+        for _ in 0..(ROUNDS / 2) {
             round!(self);
             swizzle!(self.b, self.c, self.d);
             round!(self);

--- a/src/chacha/sse2.rs
+++ b/src/chacha/sse2.rs
@@ -9,7 +9,7 @@ use core::arch::x86_64::*;
 use core::convert::TryInto;
 
 #[derive(Clone)]
-pub(crate) struct State {
+pub(crate) struct State<const ROUNDS: usize> {
     a: __m128i,
     b: __m128i,
     c: __m128i,
@@ -61,7 +61,7 @@ macro_rules! round {
     };
 }
 
-impl State {
+impl<const ROUNDS: usize> State<ROUNDS> {
     // state initialization constant le-32bit array of b"expand 16-byte k"
     const CST16: [u32; 4] = [0x61707865, 0x3120646e, 0x79622d36, 0x6b206574];
 
@@ -135,9 +135,9 @@ impl State {
     }
 
     #[inline]
-    pub(crate) fn round20(&mut self) {
+    pub(crate) fn round(&mut self) {
         unsafe {
-            for _ in 0..10 {
+            for _ in 0..(ROUNDS / 2) {
                 round!(self.a, self.b, self.c, self.d);
                 swizzle!(self.b, self.c, self.d);
                 round!(self.a, self.b, self.c, self.d);


### PR DESCRIPTION
introduce new types that are round neutral, and re-export
an alias type for the current 20-rounds types.

* `ChaCha20Poly1305` => `ChaChaPoly1305<ROUNDS>`
* `ChaCha20` => `ChaCha<ROUNDS>`
* `Salsa20` => `Salsa<ROUNDS>`