### PR TITLE
utils cleanup

### DIFF
--- a/src/blake2b.rs
+++ b/src/blake2b.rs
@@ -30,7 +30,7 @@
 //! [1]: <https://eprint.iacr.org/2013/322.pdf>
 
 use crate::blake2::{EngineB as Engine, LastBlock};
-use crate::cryptoutil::{copy_memory, write_u64v_le};
+use crate::cryptoutil::write_u64v_le;
 use crate::digest::Digest;
 use crate::mac::{Mac, MacResult};
 use crate::util::secure_memset;
@@ -88,7 +88,7 @@ impl Blake2b {
         let fill = Engine::BLOCK_BYTES - self.buflen;
 
         if input.len() > fill {
-            copy_memory(&input[0..fill], &mut self.buf[self.buflen..]);
+            self.buf[self.buflen..self.buflen + fill].copy_from_slice(&input[0..fill]);
             self.buflen = 0;
             self.eng.increment_counter(Engine::BLOCK_BYTES_NATIVE);
             self.eng
@@ -103,7 +103,7 @@ impl Blake2b {
                 input = &input[Engine::BLOCK_BYTES..];
             }
         }
-        copy_memory(input, &mut self.buf[self.buflen..]);
+        self.buf[self.buflen..self.buflen + input.len()].copy_from_slice(input);
         self.buflen += input.len();
     }
 
@@ -118,7 +118,7 @@ impl Blake2b {
             write_u64v_le(&mut self.buf[0..64], &self.eng.h);
             self.computed = true;
         }
-        copy_memory(&self.buf[0..out.len()], out);
+        out.copy_from_slice(&self.buf[0..out.len()]);
     }
 
     /// Reset the context to the state after calling `new`

--- a/src/blake2b.rs
+++ b/src/blake2b.rs
@@ -30,10 +30,9 @@
 //! [1]: <https://eprint.iacr.org/2013/322.pdf>
 
 use crate::blake2::{EngineB as Engine, LastBlock};
-use crate::cryptoutil::write_u64v_le;
+use crate::cryptoutil::{write_u64v_le, zero};
 use crate::digest::Digest;
 use crate::mac::{Mac, MacResult};
-use crate::util::secure_memset;
 use alloc::vec::Vec;
 use core::iter::repeat;
 
@@ -111,7 +110,7 @@ impl Blake2b {
         assert!(out.len() == self.digest_length as usize);
         if !self.computed {
             self.eng.increment_counter(self.buflen as u64);
-            secure_memset(&mut self.buf[self.buflen..], 0);
+            zero(&mut self.buf[self.buflen..]);
             self.eng
                 .compress(&self.buf[0..Engine::BLOCK_BYTES], LastBlock::Yes);
 
@@ -126,7 +125,7 @@ impl Blake2b {
         self.eng.reset(self.digest_length as usize, 0);
         self.computed = false;
         self.buflen = 0;
-        secure_memset(&mut self.buf[..], 0);
+        zero(&mut self.buf[..]);
     }
 
     pub fn reset_with_key(&mut self, key: &[u8]) {
@@ -134,7 +133,7 @@ impl Blake2b {
 
         self.eng.reset(self.digest_length as usize, key.len());
         self.computed = false;
-        secure_memset(&mut self.buf[..], 0);
+        zero(&mut self.buf[..]);
 
         if !key.is_empty() {
             self.buf[0..key.len()].copy_from_slice(key);

--- a/src/blake2s.rs
+++ b/src/blake2s.rs
@@ -30,7 +30,7 @@
 //! [1]: <https://eprint.iacr.org/2013/322.pdf>
 
 use crate::blake2::{EngineS as Engine, LastBlock};
-use crate::cryptoutil::{copy_memory, write_u32v_le};
+use crate::cryptoutil::write_u32v_le;
 use crate::digest::Digest;
 use crate::mac::{Mac, MacResult};
 use crate::util::secure_memset;
@@ -88,7 +88,7 @@ impl Blake2s {
         let fill = Engine::BLOCK_BYTES - self.buflen;
 
         if input.len() > fill {
-            copy_memory(&input[0..fill], &mut self.buf[self.buflen..]);
+            self.buf[self.buflen..self.buflen + fill].copy_from_slice(&input[0..fill]);
             self.buflen = 0;
             self.eng.increment_counter(Engine::BLOCK_BYTES_NATIVE);
             self.eng
@@ -103,7 +103,7 @@ impl Blake2s {
                 input = &input[Engine::BLOCK_BYTES..];
             }
         }
-        copy_memory(input, &mut self.buf[self.buflen..]);
+        self.buf[self.buflen..self.buflen + input.len()].copy_from_slice(input);
         self.buflen += input.len();
     }
 
@@ -118,7 +118,7 @@ impl Blake2s {
             write_u32v_le(&mut self.buf[0..32], &self.eng.h);
             self.computed = true;
         }
-        copy_memory(&self.buf[0..out.len()], out);
+        out.copy_from_slice(&self.buf[0..out.len()]);
     }
 
     /// Reset the context to the state after calling `new`

--- a/src/blake2s.rs
+++ b/src/blake2s.rs
@@ -30,10 +30,9 @@
 //! [1]: <https://eprint.iacr.org/2013/322.pdf>
 
 use crate::blake2::{EngineS as Engine, LastBlock};
-use crate::cryptoutil::write_u32v_le;
+use crate::cryptoutil::{write_u32v_le, zero};
 use crate::digest::Digest;
 use crate::mac::{Mac, MacResult};
-use crate::util::secure_memset;
 use alloc::vec::Vec;
 use core::iter::repeat;
 
@@ -111,7 +110,7 @@ impl Blake2s {
         assert!(out.len() == self.digest_length as usize);
         if !self.computed {
             self.eng.increment_counter(self.buflen as u32);
-            secure_memset(&mut self.buf[self.buflen..], 0);
+            zero(&mut self.buf[self.buflen..]);
             self.eng
                 .compress(&self.buf[0..Engine::BLOCK_BYTES], LastBlock::Yes);
 
@@ -126,7 +125,7 @@ impl Blake2s {
         self.eng.reset(self.digest_length as usize, 0);
         self.computed = false;
         self.buflen = 0;
-        secure_memset(&mut self.buf[..], 0);
+        zero(&mut self.buf[..]);
     }
 
     pub fn reset_with_key(&mut self, key: &[u8]) {
@@ -134,7 +133,8 @@ impl Blake2s {
 
         self.eng.reset(self.digest_length as usize, key.len());
         self.computed = false;
-        secure_memset(&mut self.buf[..], 0);
+        zero(&mut self.buf[..]);
+
         if !key.is_empty() {
             self.buf[0..key.len()].copy_from_slice(key);
             self.buflen = Engine::BLOCK_BYTES;

--- a/src/chacha20poly1305.rs
+++ b/src/chacha20poly1305.rs
@@ -68,10 +68,10 @@
 // except according to those terms.
 
 use crate::chacha20::ChaCha;
+use crate::constant_time::{Choice, CtEqual};
 use crate::cryptoutil::write_u64_le;
 use crate::mac::Mac;
 use crate::poly1305::Poly1305;
-use crate::util::fixed_time_eq;
 
 /// Chacha20Poly1305 Incremental Context for Authenticated Data (AAD)
 ///
@@ -121,9 +121,15 @@ pub struct ContextDecryption<const ROUNDS: usize>(Context<ROUNDS>);
 #[derive(Debug, Clone)]
 pub struct Tag(pub [u8; 16]);
 
+impl CtEqual for Tag {
+    fn ct_eq(&self, other: &Self) -> Choice {
+        self.0.ct_eq(&other.0)
+    }
+}
+
 impl PartialEq for Tag {
     fn eq(&self, other: &Self) -> bool {
-        fixed_time_eq(&self.0, &other.0)
+        self.ct_eq(other).is_true()
     }
 }
 

--- a/src/constant_time.rs
+++ b/src/constant_time.rs
@@ -1,0 +1,271 @@
+//! Constant time operations
+//!
+//! This module exports traits to do basic checking operation in constant time,
+//! those operations are:
+//!
+//! * CtZero : constant time zero and non-zero checking
+//! * CtEqual : constant time equality and non-equality checking
+//! * CtLesser : constant time less (<) and opposite greater-equal (>=) checking
+//! * CtGreater : constant time greater (>) and opposite lesser-equal (<=) checking
+//!
+//! And simple types to manipulate those capabilities in a safer way:
+//!
+//! * Choice : Constant time boolean and safe methods.
+//!            this was initially called CtBool but aligned to other implementation.
+//! * CtOption : Constant time Option type.
+//!
+//! Great care has been done to make operation constant so that it's useful in
+//! cryptographic context, but we're not protected from implementation bug,
+//! compiler optimisations, gamma rays and other Moon-Mars alignments.
+//!
+//! The general functionality would be a great addition to the rust core library
+//! to have those type of things built-in and crucially more eyeballs.
+
+/// Constant time boolean
+///
+/// This implementation uses a u64 under the hood, but it's never exposed
+/// and only used through abstraction that push toward more constant time
+/// operations.
+///
+/// Choice can be combined with simple And operation.
+///
+/// Choice can be converted back to a boolean operations, although
+/// once this is done, the operation will likely be non-constant.
+#[derive(Clone, Copy)]
+pub struct Choice(pub(crate) u64);
+
+/// Constant time equivalent to Option.
+///
+/// The T type is always present in the data structure,
+/// it's just marked as valid / invalid with a Choice
+/// type.
+#[derive(Clone)]
+pub struct CtOption<T> {
+    present: Choice, // if present the value is there and valid
+    t: T,
+}
+
+impl Choice {
+    pub fn is_true(self) -> bool {
+        self.0 == 1
+    }
+    pub fn is_false(self) -> bool {
+        self.0 == 0
+    }
+    pub fn negate(self) -> Self {
+        Choice(1 ^ self.0)
+    }
+}
+
+impl From<Choice> for bool {
+    fn from(c: Choice) -> bool {
+        c.is_true()
+    }
+}
+
+impl core::ops::BitAnd for Choice {
+    type Output = Choice;
+    fn bitand(self, b: Choice) -> Choice {
+        Choice(self.0 & b.0)
+    }
+}
+
+impl<T> From<(Choice, T)> for CtOption<T> {
+    fn from(c: (Choice, T)) -> CtOption<T> {
+        CtOption {
+            present: c.0,
+            t: c.1,
+        }
+    }
+}
+
+impl<T> CtOption<T> {
+    pub fn into_option(self) -> Option<T> {
+        if self.present.is_true() {
+            Some(self.t)
+        } else {
+            None
+        }
+    }
+}
+
+/// Check in constant time if the object is zero or non-zero
+///
+/// Note that zero means 0 with integer primitive, or for array of integer
+/// it means all elements are 0
+pub trait CtZero {
+    fn ct_zero(&self) -> Choice;
+    fn ct_nonzero(&self) -> Choice;
+}
+
+/// Check in constant time if the left object is greater than right object
+///
+/// This equivalent to the > operator found in the core library.
+pub trait CtGreater: Sized {
+    fn ct_gt(a: Self, b: Self) -> Choice;
+    fn ct_le(a: Self, b: Self) -> Choice {
+        Self::ct_gt(b, a)
+    }
+}
+
+/// Check in constant time if the left object is lesser than right object
+///
+/// This equivalent to the < operator found in the core library.
+pub trait CtLesser: Sized {
+    fn ct_lt(a: Self, b: Self) -> Choice;
+    fn ct_ge(a: Self, b: Self) -> Choice {
+        Self::ct_lt(b, a)
+    }
+}
+
+/// Check in constant time if the left object is equal to the right object
+///
+/// This equivalent to the == operator found in the core library.
+pub trait CtEqual<Rhs: ?Sized = Self> {
+    fn ct_eq(&self, b: &Rhs) -> Choice;
+    fn ct_ne(&self, b: &Rhs) -> Choice {
+        self.ct_eq(b).negate()
+    }
+}
+
+impl CtZero for u64 {
+    fn ct_zero(&self) -> Choice {
+        Choice(1 ^ ((self | self.wrapping_neg()) >> 63))
+    }
+    fn ct_nonzero(&self) -> Choice {
+        Choice((self | self.wrapping_neg()) >> 63)
+    }
+}
+
+impl CtEqual for u64 {
+    fn ct_eq(&self, b: &Self) -> Choice {
+        Self::ct_zero(&(self ^ b))
+    }
+    fn ct_ne(&self, b: &Self) -> Choice {
+        Self::ct_nonzero(&(self ^ b))
+    }
+}
+
+impl CtLesser for u64 {
+    fn ct_lt(a: Self, b: Self) -> Choice {
+        Choice((a ^ ((a ^ b) | ((a - b) ^ b))) >> 63)
+    }
+}
+
+impl CtGreater for u64 {
+    fn ct_gt(a: Self, b: Self) -> Choice {
+        Self::ct_lt(b, a)
+    }
+}
+
+impl<const N: usize> CtZero for [u8; N] {
+    fn ct_zero(&self) -> Choice {
+        let mut acc = 0u64;
+        for b in self.iter() {
+            acc |= *b as u64
+        }
+        acc.ct_zero()
+    }
+    fn ct_nonzero(&self) -> Choice {
+        let mut acc = 0u64;
+        for b in self.iter() {
+            acc |= *b as u64
+        }
+        acc.ct_nonzero()
+    }
+}
+
+impl<const N: usize> CtZero for [u64; N] {
+    fn ct_zero(&self) -> Choice {
+        let mut acc = 0u64;
+        for b in self.iter() {
+            acc |= b
+        }
+        acc.ct_zero()
+    }
+    fn ct_nonzero(&self) -> Choice {
+        let mut acc = 0u64;
+        for b in self.iter() {
+            acc |= b
+        }
+        acc.ct_nonzero()
+    }
+}
+
+impl CtZero for [u64] {
+    fn ct_zero(&self) -> Choice {
+        let mut acc = 0u64;
+        for b in self.iter() {
+            acc |= b
+        }
+        acc.ct_zero()
+    }
+    fn ct_nonzero(&self) -> Choice {
+        let mut acc = 0u64;
+        for b in self.iter() {
+            acc |= b
+        }
+        acc.ct_nonzero()
+    }
+}
+
+impl<const N: usize> CtEqual for [u8; N] {
+    fn ct_eq(&self, b: &[u8; N]) -> Choice {
+        let mut acc = 0u64;
+        for (x, y) in self.iter().zip(b.iter()) {
+            acc |= (*x as u64) ^ (*y as u64);
+        }
+        acc.ct_zero()
+    }
+}
+impl<const N: usize> CtEqual for [u64; N] {
+    fn ct_eq(&self, b: &[u64; N]) -> Choice {
+        let mut acc = 0u64;
+        for (x, y) in self.iter().zip(b.iter()) {
+            acc |= x ^ y;
+        }
+        acc.ct_zero()
+    }
+}
+
+impl CtEqual for [u64] {
+    fn ct_eq(&self, b: &[u64]) -> Choice {
+        assert_eq!(self.len(), b.len());
+        let mut acc = 0u64;
+        for (x, y) in self.iter().zip(b.iter()) {
+            acc |= x ^ y;
+        }
+        acc.ct_zero()
+    }
+}
+
+// big endian representation of a number, but also leading byte of a array being the MSB.
+impl<const N: usize> CtLesser for &[u8; N] {
+    fn ct_lt(a: Self, b: Self) -> Choice {
+        let mut borrow = 0u8;
+        for (x, y) in a.iter().rev().zip(b.iter().rev()) {
+            let x1: i16 = ((*x as i16) - (borrow as i16)) - (*y as i16);
+            let x2: i8 = (x1 >> 8) as i8;
+            borrow = (0x0 - x2) as u8;
+        }
+        let borrow = borrow as u64;
+        Choice((borrow | borrow.wrapping_neg()) >> 63)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ct_zero() {
+        assert_eq!(0u64.ct_zero().is_true(), true);
+        assert_eq!(1u64.ct_zero().is_false(), true);
+    }
+
+    #[test]
+    fn test_ct_less() {
+        let a: [u8; 4] = [0u8, 1, 2, 3];
+        assert_eq!(<&[u8; 4]>::ct_lt(&a, &[1, 1, 2, 3]).is_true(), true);
+    }
+}

--- a/src/hkdf.rs
+++ b/src/hkdf.rs
@@ -19,7 +19,6 @@
 use alloc::vec::Vec;
 use core::iter::repeat;
 
-use crate::cryptoutil::copy_memory;
 use crate::digest::Digest;
 use crate::hmac::Hmac;
 use crate::mac::Mac;
@@ -72,7 +71,7 @@ pub fn hkdf_expand<D: Digest>(mut digest: D, prk: &[u8], info: &[u8], okm: &mut 
         mac.raw_result(&mut t);
         mac.reset();
         let chunk_len = chunk.len();
-        copy_memory(&t[..chunk_len], chunk);
+        chunk[0..chunk_len].copy_from_slice(&t[..chunk_len]);
     }
 }
 

--- a/src/hmac.rs
+++ b/src/hmac.rs
@@ -16,7 +16,6 @@
 
 use core::iter::repeat;
 
-use crate::cryptoutil;
 use crate::digest::Digest;
 use crate::mac::{Mac, MacResult};
 use alloc::vec::Vec;
@@ -43,7 +42,7 @@ fn expand_key<D: Digest>(digest: &mut D, key: &[u8]) -> Vec<u8> {
     let mut expanded_key: Vec<u8> = repeat(0).take(bs).collect();
 
     if key.len() <= bs {
-        cryptoutil::copy_memory(key, &mut expanded_key);
+        expanded_key[0..key.len()].copy_from_slice(key);
     } else {
         let output_size = digest.output_bytes();
         digest.input(key);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,3 +98,5 @@ pub mod sha3;
 mod cryptoutil;
 mod simd;
 pub mod util;
+
+pub mod constant_time;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,6 +97,6 @@ pub mod sha3;
 
 mod cryptoutil;
 mod simd;
-pub mod util;
+mod util;
 
 pub mod constant_time;

--- a/src/pbkdf2.rs
+++ b/src/pbkdf2.rs
@@ -20,7 +20,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use crate::cryptoutil::{copy_memory, write_u32_be};
+use crate::cryptoutil::write_u32_be;
 use crate::mac::Mac;
 use alloc::vec::Vec;
 use core::iter::repeat;
@@ -107,7 +107,7 @@ pub fn pbkdf2<M: Mac>(mac: &mut M, salt: &[u8], c: u32, output: &mut [u8]) {
             let mut tmp: Vec<u8> = repeat(0).take(os).collect();
             calculate_block(mac, salt, c, idx, &mut scratch[..], &mut tmp[..]);
             let chunk_len = chunk.len();
-            copy_memory(&tmp[..chunk_len], chunk);
+            chunk[0..chunk_len].copy_from_slice(&tmp[..chunk_len]);
         }
     }
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,16 +1,3 @@
-//! Various utilities
-// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
-// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
-// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
-// option. This file may not be copied, modified, or distributed
-// except according to those terms.
-
-pub fn secure_memset(dst: &mut [u8], val: u8) {
-    for d in dst.iter_mut() {
-        *d = val;
-    }
-}
-
 /// Compare two vectors using a fixed number of operations. If the two vectors are not of equal
 /// length, the function returns false immediately.
 pub fn fixed_time_eq(lhs: &[u8], rhs: &[u8]) -> bool {


### PR DESCRIPTION
* remove `copy_memory` in favor of slice method's `copy_from_slice` 
* remove `secure_memset` in favor of using `zero`, specially since it was only used to wipe memory to zero
* add `constant_time` module from eccoxide
* add constant_time `CtEqual` instance to ChaChaPoly1305's `Tag`
* hide `utils` module from export list