### PR TITLE
add x86 imports in blake2/avx2

### DIFF
--- a/src/hashing/blake2/avx2.rs
+++ b/src/hashing/blake2/avx2.rs
@@ -1,5 +1,8 @@
 use super::common::{b, LastBlock};
 
+#[cfg(target_arch = "x86")]
+use core::arch::x86::*;
+
 #[cfg(target_arch = "x86_64")]
 use core::arch::x86_64::*;
 


### PR DESCRIPTION
This mirrors `avx.rs`. For context, I ran into this when trying to compile for i686-linux-android.