### PR TITLE
Fix benchmark compilation: sha1_digest_block_u32 -> digest_block_u32

### DIFF
--- a/src/hashing/sha1.rs
+++ b/src/hashing/sha1.rs
@@ -487,7 +487,7 @@ mod bench {
         let mut state = [0u32; STATE_LEN];
         let words = [1u32; BLOCK_LEN];
         bh.iter(|| {
-            sha1_digest_block_u32(&mut state, &words);
+            digest_block_u32(&mut state, &words);
         });
         bh.bytes = 64u64;
     }


### PR DESCRIPTION
Benchmarks compilation invoked by
```
 cargo +nightly bench --features with-bench
```
is failing for me with
```
cannot find function `sha1_digest_block_u32` in this scope
   --> src/hashing/sha1.rs:490:13
```
It looks like sha1_digest_block_u32 was renamed at some point, but still called from one of the benchmarks