### PR TITLE
[Blake2] add ContextDyn to keep the output dynamic at the value level

### DIFF
--- a/src/blake2b.rs
+++ b/src/blake2b.rs
@@ -35,89 +35,12 @@ use crate::mac::{Mac, MacResult};
 use alloc::vec::Vec;
 use core::iter::repeat;
 
-#[derive(Clone)]
-pub enum Context {
-    Context8(blake2b::Context<8>),
-    Context16(blake2b::Context<16>),
-    Context32(blake2b::Context<32>),
-    Context64(blake2b::Context<64>),
-    Context128(blake2b::Context<128>),
-    Context160(blake2b::Context<160>),
-    Context192(blake2b::Context<192>),
-    Context224(blake2b::Context<224>),
-    Context256(blake2b::Context<256>),
-    Context264(blake2b::Context<264>),
-    Context288(blake2b::Context<288>),
-    Context320(blake2b::Context<320>),
-    Context352(blake2b::Context<352>),
-    Context384(blake2b::Context<384>),
-    Context512(blake2b::Context<512>),
-}
-
-macro_rules! ctx_pass {
-    ($self:ident, $name:ident ($($input:expr)*)) => {
-        match $self {
-            Context::Context8(ctx) => ctx.$name ($($input)*),
-            Context::Context16(ctx) => ctx.$name ($($input)*),
-            Context::Context32(ctx) => ctx.$name ($($input)*),
-            Context::Context64(ctx) => ctx.$name ($($input)*),
-            Context::Context128(ctx) => ctx.$name ($($input)*),
-            Context::Context160(ctx) => ctx.$name ($($input)*),
-            Context::Context192(ctx) => ctx.$name ($($input)*),
-            Context::Context224(ctx) => ctx.$name ($($input)*),
-            Context::Context256(ctx) => ctx.$name ($($input)*),
-            Context::Context264(ctx) => ctx.$name ($($input)*),
-            Context::Context288(ctx) => ctx.$name ($($input)*),
-            Context::Context320(ctx) => ctx.$name ($($input)*),
-            Context::Context352(ctx) => ctx.$name ($($input)*),
-            Context::Context384(ctx) => ctx.$name ($($input)*),
-            Context::Context512(ctx) => ctx.$name ($($input)*),
-        }
-    };
-}
-
-impl Context {
-    fn digest_length(&self) -> usize {
-        match self {
-            Context::Context8(_) => 1,
-            Context::Context16(_) => 2,
-            Context::Context32(_) => 4,
-            Context::Context64(_) => 8,
-            Context::Context128(_) => 16,
-            Context::Context160(_) => 20,
-            Context::Context192(_) => 24,
-            Context::Context224(_) => 28,
-            Context::Context256(_) => 32,
-            Context::Context264(_) => 33,
-            Context::Context288(_) => 36,
-            Context::Context320(_) => 40,
-            Context::Context352(_) => 44,
-            Context::Context384(_) => 48,
-            Context::Context512(_) => 64,
-        }
-    }
-
-    fn update_mut(&mut self, input: &[u8]) {
-        ctx_pass!(self, update_mut(input))
-    }
-
-    fn reset(&mut self) {
-        ctx_pass!(self, reset())
-    }
-
-    fn reset_with_key(&mut self, key: &[u8]) {
-        ctx_pass!(self, reset_with_key(key))
-    }
-
-    fn finalize_reset_at(&mut self, out: &mut [u8]) {
-        ctx_pass!(self, finalize_reset_at(out))
-    }
-}
+pub type Context = blake2b::ContextDyn;
 
 /// Blake2b Context
 #[derive(Clone)]
 pub struct Blake2b {
-    ctx: Context,
+    ctx: blake2b::ContextDyn,
     computed: bool, // whether the final digest has been computed
 }
 
@@ -126,24 +49,7 @@ impl Blake2b {
     ///
     /// the size need to be between 0 (non included) and 64 bytes (included)
     pub fn new(outlen: usize) -> Self {
-        let ctx = match outlen {
-            1 => Context::Context8(blake2b::Context::new()),
-            2 => Context::Context16(blake2b::Context::new()),
-            4 => Context::Context32(blake2b::Context::new()),
-            8 => Context::Context64(blake2b::Context::new()),
-            16 => Context::Context128(blake2b::Context::new()),
-            20 => Context::Context160(blake2b::Context::new()),
-            24 => Context::Context192(blake2b::Context::new()),
-            28 => Context::Context224(blake2b::Context::new()),
-            32 => Context::Context256(blake2b::Context::new()),
-            33 => Context::Context264(blake2b::Context::new()),
-            36 => Context::Context288(blake2b::Context::new()),
-            40 => Context::Context320(blake2b::Context::new()),
-            44 => Context::Context352(blake2b::Context::new()),
-            48 => Context::Context384(blake2b::Context::new()),
-            64 => Context::Context512(blake2b::Context::new()),
-            _ => panic!("outlen > 0 && outlen <= 64"),
-        };
+        let ctx = blake2b::ContextDyn::new(outlen);
         Self {
             ctx,
             computed: false,
@@ -154,24 +60,7 @@ impl Blake2b {
     /// to tweak the context initialization
     pub fn new_keyed(outlen: usize, key: &[u8]) -> Self {
         assert!(key.len() <= 64);
-        let ctx = match outlen {
-            1 => Context::Context8(blake2b::Context::new_keyed(key)),
-            2 => Context::Context16(blake2b::Context::new_keyed(key)),
-            4 => Context::Context32(blake2b::Context::new_keyed(key)),
-            8 => Context::Context64(blake2b::Context::new_keyed(key)),
-            16 => Context::Context128(blake2b::Context::new_keyed(key)),
-            20 => Context::Context160(blake2b::Context::new_keyed(key)),
-            24 => Context::Context192(blake2b::Context::new_keyed(key)),
-            28 => Context::Context224(blake2b::Context::new_keyed(key)),
-            32 => Context::Context256(blake2b::Context::new_keyed(key)),
-            33 => Context::Context264(blake2b::Context::new_keyed(key)),
-            36 => Context::Context288(blake2b::Context::new_keyed(key)),
-            40 => Context::Context320(blake2b::Context::new_keyed(key)),
-            44 => Context::Context352(blake2b::Context::new_keyed(key)),
-            48 => Context::Context384(blake2b::Context::new_keyed(key)),
-            64 => Context::Context512(blake2b::Context::new_keyed(key)),
-            _ => panic!("outlen > 0 && outlen <= 64"),
-        };
+        let ctx = blake2b::ContextDyn::new_keyed(outlen, key);
         Self {
             ctx,
             computed: false,
@@ -223,7 +112,7 @@ impl Digest for Blake2b {
         self.finalize(out);
     }
     fn output_bits(&self) -> usize {
-        8 * (self.ctx.digest_length())
+        8 * (self.ctx.output_bits())
     }
     fn block_size(&self) -> usize {
         // hack : this is a constant, not related to the number of bit
@@ -241,7 +130,7 @@ impl Mac for Blake2b {
     }
 
     fn result(&mut self) -> MacResult {
-        let mut mac: Vec<u8> = repeat(0).take(self.ctx.digest_length()).collect();
+        let mut mac: Vec<u8> = repeat(0).take(self.ctx.output_bits() / 8).collect();
         self.raw_result(&mut mac);
         MacResult::new_from_owned(mac)
     }
@@ -251,7 +140,7 @@ impl Mac for Blake2b {
     }
 
     fn output_bytes(&self) -> usize {
-        self.ctx.digest_length()
+        self.ctx.output_bits() / 8
     }
 }
 

--- a/src/blake2s.rs
+++ b/src/blake2s.rs
@@ -35,68 +35,12 @@ use crate::mac::{Mac, MacResult};
 use alloc::vec::Vec;
 use core::iter::repeat;
 
-#[derive(Clone)]
-pub enum Context {
-    Context8(blake2s::Context<8>),
-    Context16(blake2s::Context<16>),
-    Context32(blake2s::Context<32>),
-    Context64(blake2s::Context<64>),
-    Context128(blake2s::Context<128>),
-    Context192(blake2s::Context<192>),
-    Context224(blake2s::Context<224>),
-    Context256(blake2s::Context<256>),
-}
+pub type Context = blake2s::ContextDyn;
 
-macro_rules! ctx_pass {
-    ($self:ident, $name:ident ($($input:expr)*)) => {
-        match $self {
-            Context::Context8(ctx) => ctx.$name ($($input)*),
-            Context::Context16(ctx) => ctx.$name ($($input)*),
-            Context::Context32(ctx) => ctx.$name ($($input)*),
-            Context::Context64(ctx) => ctx.$name ($($input)*),
-            Context::Context128(ctx) => ctx.$name ($($input)*),
-            Context::Context192(ctx) => ctx.$name ($($input)*),
-            Context::Context224(ctx) => ctx.$name ($($input)*),
-            Context::Context256(ctx) => ctx.$name ($($input)*),
-        }
-    };
-}
-
-impl Context {
-    fn digest_length(&self) -> usize {
-        match self {
-            Context::Context8(_) => 1,
-            Context::Context16(_) => 2,
-            Context::Context32(_) => 4,
-            Context::Context64(_) => 8,
-            Context::Context128(_) => 16,
-            Context::Context192(_) => 24,
-            Context::Context224(_) => 28,
-            Context::Context256(_) => 32,
-        }
-    }
-
-    fn update_mut(&mut self, input: &[u8]) {
-        ctx_pass!(self, update_mut(input))
-    }
-
-    fn reset(&mut self) {
-        ctx_pass!(self, reset())
-    }
-
-    fn reset_with_key(&mut self, key: &[u8]) {
-        ctx_pass!(self, reset_with_key(key))
-    }
-
-    fn finalize_reset_at(&mut self, out: &mut [u8]) {
-        ctx_pass!(self, finalize_reset_at(out))
-    }
-}
-
-/// Blake2b Context
+/// Blake2s Context
 #[derive(Clone)]
 pub struct Blake2s {
-    ctx: Context,
+    ctx: blake2s::ContextDyn,
     computed: bool, // whether the final digest has been computed
 }
 
@@ -105,17 +49,7 @@ impl Blake2s {
     ///
     /// the size need to be between 0 (non included) and 32 bytes (included)
     pub fn new(outlen: usize) -> Self {
-        let ctx = match outlen {
-            1 => Context::Context8(blake2s::Context::new()),
-            2 => Context::Context16(blake2s::Context::new()),
-            4 => Context::Context32(blake2s::Context::new()),
-            8 => Context::Context64(blake2s::Context::new()),
-            16 => Context::Context128(blake2s::Context::new()),
-            24 => Context::Context192(blake2s::Context::new()),
-            28 => Context::Context224(blake2s::Context::new()),
-            32 => Context::Context256(blake2s::Context::new()),
-            _ => panic!("outlen > 0 && outlen <= 64"),
-        };
+        let ctx = blake2s::ContextDyn::new(outlen);
         Self {
             ctx,
             computed: false,
@@ -125,17 +59,8 @@ impl Blake2s {
     /// Similar to `new` but also takes a variable size key
     /// to tweak the context initialization
     pub fn new_keyed(outlen: usize, key: &[u8]) -> Self {
-        let ctx = match outlen {
-            1 => Context::Context8(blake2s::Context::new_keyed(key)),
-            2 => Context::Context16(blake2s::Context::new_keyed(key)),
-            4 => Context::Context32(blake2s::Context::new_keyed(key)),
-            8 => Context::Context64(blake2s::Context::new_keyed(key)),
-            16 => Context::Context128(blake2s::Context::new_keyed(key)),
-            24 => Context::Context192(blake2s::Context::new_keyed(key)),
-            28 => Context::Context224(blake2s::Context::new_keyed(key)),
-            32 => Context::Context256(blake2s::Context::new_keyed(key)),
-            _ => panic!("outlen > 0 && outlen <= 32"),
-        };
+        assert!(key.len() <= 64);
+        let ctx = blake2s::ContextDyn::new_keyed(outlen, key);
         Self {
             ctx,
             computed: false,
@@ -187,7 +112,7 @@ impl Digest for Blake2s {
         self.finalize(out);
     }
     fn output_bits(&self) -> usize {
-        8 * (self.ctx.digest_length())
+        8 * (self.ctx.output_bits())
     }
     fn block_size(&self) -> usize {
         // hack : this is a constant, not related to the number of bit
@@ -205,7 +130,7 @@ impl Mac for Blake2s {
     }
 
     fn result(&mut self) -> MacResult {
-        let mut mac: Vec<u8> = repeat(0).take(self.ctx.digest_length()).collect();
+        let mut mac: Vec<u8> = repeat(0).take(self.ctx.output_bits() / 8).collect();
         self.raw_result(&mut mac);
         MacResult::new_from_owned(mac)
     }
@@ -215,7 +140,7 @@ impl Mac for Blake2s {
     }
 
     fn output_bytes(&self) -> usize {
-        self.ctx.digest_length()
+        self.ctx.output_bits() / 8
     }
 }
 

--- a/src/hashing/blake2s.rs
+++ b/src/hashing/blake2s.rs
@@ -56,10 +56,20 @@ pub struct Context<const BITS: usize> {
     buflen: usize,
 }
 
+/// Blake2s Context with dynamic output size determined by initial parameter
+#[derive(Clone)]
+pub struct ContextDyn {
+    eng: Engine,
+    buf: [u8; Engine::BLOCK_BYTES],
+    buflen: usize,
+    outlen: usize,
+}
+
 impl<const BITS: usize> Context<BITS> {
     /// Create a new Blake2s context with a specific output size in bytes
     ///
-    /// the size need to be between 0 (non included) and 32 bytes (included)
+    /// the size in bytes need to be between 0 (non included) and 32 bytes (included),
+    /// which means BITS need to be between 1 and 256.
     pub fn new() -> Self {
         assert!(BITS > 0 && ((BITS + 7) / 8) <= Engine::MAX_OUTLEN);
         Self::new_keyed(&[])
@@ -164,6 +174,127 @@ impl<const BITS: usize> Context<BITS> {
             self.buf = [0; Engine::BLOCK_BYTES];
             self.buflen = 0;
         }
+    }
+}
+
+impl ContextDyn {
+    /// Create a new Blake2s context with a specific output size in bytes
+    ///
+    /// the size in bytes need to be between 0 (non included) and 32 bytes (included),
+    /// which means BITS need to be between 1 and 256.
+    pub fn new(output_bytes: usize) -> Self {
+        assert!(output_bytes > 0 && output_bytes <= Engine::MAX_OUTLEN);
+        Self::new_keyed(output_bytes, &[])
+    }
+
+    /// Similar to `new` but also takes a variable size key
+    /// to tweak the context initialization
+    pub fn new_keyed(output_bytes: usize, key: &[u8]) -> Self {
+        assert!(output_bytes > 0 && output_bytes <= Engine::MAX_OUTLEN);
+        assert!(key.len() <= Engine::MAX_KEYLEN);
+
+        let mut buf = [0u8; Engine::BLOCK_BYTES];
+
+        let eng = Engine::new(output_bytes, key.len());
+        let buflen = if !key.is_empty() {
+            buf[0..key.len()].copy_from_slice(key);
+            Engine::BLOCK_BYTES
+        } else {
+            0
+        };
+
+        Self {
+            eng,
+            buf,
+            buflen,
+            outlen: output_bytes,
+        }
+    }
+
+    pub fn update(mut self, input: &[u8]) -> Self {
+        self.update_mut(input);
+        self
+    }
+
+    pub fn update_mut(&mut self, mut input: &[u8]) {
+        if input.is_empty() {
+            return;
+        }
+        let fill = Engine::BLOCK_BYTES - self.buflen;
+
+        if input.len() > fill {
+            self.buf[self.buflen..self.buflen + fill].copy_from_slice(&input[0..fill]);
+            self.buflen = 0;
+            self.eng.increment_counter(Engine::BLOCK_BYTES_NATIVE);
+            self.eng
+                .compress(&self.buf[0..Engine::BLOCK_BYTES], LastBlock::No);
+
+            input = &input[fill..];
+
+            while input.len() > Engine::BLOCK_BYTES {
+                self.eng.increment_counter(Engine::BLOCK_BYTES_NATIVE);
+                self.eng
+                    .compress(&input[0..Engine::BLOCK_BYTES], LastBlock::No);
+                input = &input[Engine::BLOCK_BYTES..];
+            }
+        }
+        self.buf[self.buflen..self.buflen + input.len()].copy_from_slice(input);
+        self.buflen += input.len();
+    }
+
+    fn internal_final(&mut self) {
+        self.eng.increment_counter(self.buflen as u32);
+        zero(&mut self.buf[self.buflen..]);
+        self.eng
+            .compress(&self.buf[0..Engine::BLOCK_BYTES], LastBlock::Yes);
+
+        write_u32v_le(&mut self.buf[0..32], &self.eng.h);
+    }
+
+    pub fn finalize_at(mut self, out: &mut [u8]) {
+        assert!(out.len() == self.outlen);
+        self.internal_final();
+        out.copy_from_slice(&self.buf[0..out.len()]);
+    }
+
+    pub fn finalize_reset_at(&mut self, out: &mut [u8]) {
+        assert!(out.len() == self.outlen);
+        self.internal_final();
+        out.copy_from_slice(&self.buf[0..out.len()]);
+        self.reset();
+    }
+
+    pub fn finalize_reset_with_key_at(&mut self, key: &[u8], out: &mut [u8]) {
+        assert!(out.len() == self.outlen);
+        self.internal_final();
+        out.copy_from_slice(&self.buf[0..out.len()]);
+        self.reset_with_key(key);
+    }
+
+    /// Reset the context to the state after calling `new`
+    pub fn reset(&mut self) {
+        self.eng.reset(self.outlen, 0);
+        self.buflen = 0;
+        zero(&mut self.buf[..]);
+    }
+
+    pub fn reset_with_key(&mut self, key: &[u8]) {
+        assert!(key.len() <= Engine::MAX_KEYLEN);
+
+        self.eng.reset(self.outlen, key.len());
+        zero(&mut self.buf[..]);
+
+        if !key.is_empty() {
+            self.buf[0..key.len()].copy_from_slice(key);
+            self.buflen = Engine::BLOCK_BYTES;
+        } else {
+            self.buf = [0; Engine::BLOCK_BYTES];
+            self.buflen = 0;
+        }
+    }
+
+    pub fn output_bits(&self) -> usize {
+        self.outlen * 8
     }
 }
 


### PR DESCRIPTION
till we get existential types, to be able to summon a variable into type we need this workaround.