### PR TITLE
Compilation for x86 x86_64 without AVX

### DIFF
--- a/src/hashing/blake2/mod.rs
+++ b/src/hashing/blake2/mod.rs
@@ -9,10 +9,10 @@ mod reference;
 
 pub use common::LastBlock;
 
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[cfg(all(any(target_arch = "x86", target_arch = "x86_64"), target_feature = "avx"))]
 mod avx;
 
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[cfg(all(any(target_arch = "x86", target_arch = "x86_64"), target_feature = "avx2"))]
 mod avx2;
 
 use common::{b, s};
@@ -59,8 +59,11 @@ impl EngineS {
             #[cfg(not(target_feature = "avx"))]
             const HAS_AVX: bool = false;
 
-            if HAS_AVX {
-                return avx::compress_s(&mut self.h, &mut self.t, buf, last);
+            #[cfg(target_feature = "avx")]
+            {
+                if HAS_AVX {
+                    return avx::compress_s(&mut self.h, &mut self.t, buf, last);
+                }
             }
         }
         reference::compress_s(&mut self.h, &mut self.t, buf, last)
@@ -115,11 +118,18 @@ impl EngineB {
             #[cfg(not(target_feature = "avx2"))]
             const HAS_AVX2: bool = false;
 
-            if HAS_AVX2 {
-                return avx2::compress_b(&mut self.h, &mut self.t, buf, last);
+            #[cfg(target_feature = "avx2")]
+            {
+                if HAS_AVX2 {
+                    return avx2::compress_b(&mut self.h, &mut self.t, buf, last);
+                }
             }
-            if HAS_AVX {
-                return avx::compress_b(&mut self.h, &mut self.t, buf, last);
+
+            #[cfg(target_feature = "avx")]
+            {
+                if HAS_AVX {
+                    return avx::compress_b(&mut self.h, &mut self.t, buf, last);
+                }
             }
         }
         reference::compress_b(&mut self.h, &mut self.t, buf, last)

--- a/src/hashing/blake2/mod.rs
+++ b/src/hashing/blake2/mod.rs
@@ -9,10 +9,16 @@ mod reference;
 
 pub use common::LastBlock;
 
-#[cfg(all(any(target_arch = "x86", target_arch = "x86_64"), target_feature = "avx"))]
+#[cfg(all(
+    any(target_arch = "x86", target_arch = "x86_64"),
+    target_feature = "avx"
+))]
 mod avx;
 
-#[cfg(all(any(target_arch = "x86", target_arch = "x86_64"), target_feature = "avx2"))]
+#[cfg(all(
+    any(target_arch = "x86", target_arch = "x86_64"),
+    target_feature = "avx2"
+))]
 mod avx2;
 
 use common::{b, s};

--- a/src/hashing/sha2/impl256/mod.rs
+++ b/src/hashing/sha2/impl256/mod.rs
@@ -10,9 +10,17 @@
 
 #[cfg(all(target_arch = "aarch64", feature = "use-stdsimd"))]
 mod aarch64;
-#[cfg(all(any(target_arch = "x86", target_arch = "x86_64"), target_feature = "avx"))]
+
+#[cfg(all(
+    any(target_arch = "x86", target_arch = "x86_64"),
+    target_feature = "avx"
+))]
 mod avx;
-#[cfg(all(any(target_arch = "x86", target_arch = "x86_64"), target_feature = "sse4.1"))]
+
+#[cfg(all(
+    any(target_arch = "x86", target_arch = "x86_64"),
+    target_feature = "sse4.1"
+))]
 mod sse41;
 //TODO not finished yet
 //#[cfg(all(target_arch = "x86_64", target_feature = "sha"))]

--- a/src/hashing/sha2/impl256/mod.rs
+++ b/src/hashing/sha2/impl256/mod.rs
@@ -10,9 +10,9 @@
 
 #[cfg(all(target_arch = "aarch64", feature = "use-stdsimd"))]
 mod aarch64;
-#[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
+#[cfg(all(any(target_arch = "x86", target_arch = "x86_64"), target_feature = "avx"))]
 mod avx;
-#[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
+#[cfg(all(any(target_arch = "x86", target_arch = "x86_64"), target_feature = "sse4.1"))]
 mod sse41;
 //TODO not finished yet
 //#[cfg(all(target_arch = "x86_64", target_feature = "sha"))]
@@ -35,11 +35,18 @@ pub(crate) fn digest_block(state: &mut [u32; 8], block: &[u8]) {
         #[cfg(not(target_feature = "sse4.1"))]
         const HAS_SSE41: bool = false;
 
-        if HAS_AVX {
-            return avx::digest_block(state, block);
+        #[cfg(target_feature = "avx")]
+        {
+            if HAS_AVX {
+                return avx::digest_block(state, block);
+            }
         }
-        if HAS_SSE41 {
-            return sse41::digest_block(state, block);
+
+        #[cfg(target_feature = "sse4.1")]
+        {
+            if HAS_SSE41 {
+                return sse41::digest_block(state, block);
+            }
         }
     }
     #[cfg(target_arch = "aarch64")]


### PR DESCRIPTION
Hi! I have faced a problem when compilation for x86 or x86_64 without AVX emits an error. It happens because there isn't a restriction for a compiler not to compile a code with AVX intrinsics when that feature is not available. So I have prepared the fix for that case, and I would appreciate it if you check this PR.