### PR TITLE
blake2b: fix output-bits in digest

### DIFF
--- a/src/blake2b.rs
+++ b/src/blake2b.rs
@@ -112,7 +112,7 @@ impl Digest for Blake2b {
         self.finalize(out);
     }
     fn output_bits(&self) -> usize {
-        8 * (self.ctx.output_bits())
+        self.ctx.output_bits()
     }
     fn block_size(&self) -> usize {
         // hack : this is a constant, not related to the number of bit


### PR DESCRIPTION
Previously, `output_bits()` (and therefore `output_bytes()` would return a value 8 times to large.