### PR TITLE
Remove dead code for cpu feature detection

### DIFF
--- a/src/hashing/blake2/mod.rs
+++ b/src/hashing/blake2/mod.rs
@@ -61,15 +61,8 @@ impl EngineS {
         #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
         {
             #[cfg(target_feature = "avx")]
-            const HAS_AVX: bool = true;
-            #[cfg(not(target_feature = "avx"))]
-            const HAS_AVX: bool = false;
-
-            #[cfg(target_feature = "avx")]
             {
-                if HAS_AVX {
-                    return avx::compress_s(&mut self.h, &mut self.t, buf, last);
-                }
+                return avx::compress_s(&mut self.h, &mut self.t, buf, last);
             }
         }
         reference::compress_s(&mut self.h, &mut self.t, buf, last)
@@ -114,28 +107,14 @@ impl EngineB {
     pub fn compress(&mut self, buf: &[u8], last: LastBlock) {
         #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
         {
-            #[cfg(target_feature = "avx")]
-            const HAS_AVX: bool = true;
-            #[cfg(not(target_feature = "avx"))]
-            const HAS_AVX: bool = false;
-
-            #[cfg(target_feature = "avx2")]
-            const HAS_AVX2: bool = true;
-            #[cfg(not(target_feature = "avx2"))]
-            const HAS_AVX2: bool = false;
-
             #[cfg(target_feature = "avx2")]
             {
-                if HAS_AVX2 {
-                    return avx2::compress_b(&mut self.h, &mut self.t, buf, last);
-                }
+                return avx2::compress_b(&mut self.h, &mut self.t, buf, last);
             }
 
             #[cfg(target_feature = "avx")]
             {
-                if HAS_AVX {
-                    return avx::compress_b(&mut self.h, &mut self.t, buf, last);
-                }
+                return avx::compress_b(&mut self.h, &mut self.t, buf, last);
             }
         }
         reference::compress_b(&mut self.h, &mut self.t, buf, last)

--- a/src/hashing/sha2/impl256/mod.rs
+++ b/src/hashing/sha2/impl256/mod.rs
@@ -32,29 +32,14 @@ mod reference;
 pub(crate) fn digest_block(state: &mut [u32; 8], block: &[u8]) {
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     {
-        /// in waiting for https://github.com/rust-lang/rfcs/pull/2725
-        #[cfg(target_feature = "avx")]
-        const HAS_AVX: bool = true;
-        #[cfg(not(target_feature = "avx"))]
-        const HAS_AVX: bool = false;
-
-        #[cfg(target_feature = "sse4.1")]
-        const HAS_SSE41: bool = true;
-        #[cfg(not(target_feature = "sse4.1"))]
-        const HAS_SSE41: bool = false;
-
         #[cfg(target_feature = "avx")]
         {
-            if HAS_AVX {
-                return avx::digest_block(state, block);
-            }
+            return avx::digest_block(state, block);
         }
 
         #[cfg(target_feature = "sse4.1")]
         {
-            if HAS_SSE41 {
-                return sse41::digest_block(state, block);
-            }
+            return sse41::digest_block(state, block);
         }
     }
     #[cfg(target_arch = "aarch64")]


### PR DESCRIPTION
The updated CPU feature detection code no longer requires HAS_AVX variables because the functionality is already gated by feature detection. This gets rid of the dead code warnings while compiling.