### PR TITLE
add support for AES128 and AES256

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Fix SHA2-256 neon optimisation completely disabled by missing feature flag
 * Add SHA2-512 neon optimisation
 * Add SHA3/Keccak aarch64 optimisation using the ARMv8.2 SHA-3 crypto extensions
+* Add AES-128 and AES-256 block cipher: constant-time fixsliced software backend, plus an aarch64 ARMv8 hardware backend using the AES crypto extensions
 
 # 0.5.1
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,8 @@ doctest = false
 [dependencies]
 
 [features]
-default = ["argon2", "blake2", "blake3", "sha1", "sha2", "sha3", "ripemd160", "chacha", "salsa", "hkdf", "hmac", "pbkdf2", "poly1305", "scrypt", "curve25519", "ed25519", "x25519"]
+default = ["aes", "argon2", "blake2", "blake3", "sha1", "sha2", "sha3", "ripemd160", "chacha", "salsa", "hkdf", "hmac", "pbkdf2", "poly1305", "scrypt", "curve25519", "ed25519", "x25519"]
+aes = []
 blake2 = ["digest", "mac"]
 blake3 = []
 sha1 = ["digest"]

--- a/src/aes/aarch64.rs
+++ b/src/aes/aarch64.rs
@@ -1,0 +1,204 @@
+//! AES block cipher using the ARMv8 Cryptography Extensions.
+//!
+//! Uses the AES instructions available under the `aes` aarch64 target feature:
+//! `vaese`/`vaesmc` for encryption and `vaesd`/`vaesimc` for decryption. The
+//! round keys are expanded once at construction time using the standard
+//! Rijndael key schedule; the S-box needed by the schedule is applied with a
+//! single-round `vaese` against an all-zero key.
+//!
+//! This module is only compiled when the `aes` target feature is enabled at
+//! compile time, so the intrinsics can be used from plain `unsafe` blocks
+//! without per-function `#[target_feature]` gating.
+
+use core::arch::aarch64::*;
+use core::mem;
+
+/// AES-128 round keys: the 11 encryption and 11 decryption round keys, already
+/// in vector form ready to be fed to the AES instructions.
+#[derive(Clone)]
+pub(super) struct RoundKeys128 {
+    enc: [uint8x16_t; 11],
+    dec: [uint8x16_t; 11],
+}
+
+/// AES-256 round keys: the 15 encryption and 15 decryption round keys, already
+/// in vector form ready to be fed to the AES instructions.
+#[derive(Clone)]
+pub(super) struct RoundKeys256 {
+    enc: [uint8x16_t; 15],
+    dec: [uint8x16_t; 15],
+}
+
+impl Drop for RoundKeys128 {
+    fn drop(&mut self) {
+        unsafe {
+            let zero = vdupq_n_u8(0);
+            self.enc = [zero; 11];
+            self.dec = [zero; 11];
+        }
+    }
+}
+
+impl Drop for RoundKeys256 {
+    fn drop(&mut self) {
+        unsafe {
+            let zero = vdupq_n_u8(0);
+            self.enc = [zero; 15];
+            self.dec = [zero; 15];
+        }
+    }
+}
+
+/// AES round constants (Rcon), one per key-schedule iteration.
+const ROUND_CONSTS: [u32; 10] = [0x01, 0x02, 0x04, 0x08, 0x10, 0x20, 0x40, 0x80, 0x1b, 0x36];
+
+/// SubBytes for a single 32-bit word, used by the key schedule.
+///
+/// The word is broadcast into all four columns of an AES state and run through
+/// a single `vaese` round with an all-zero key. Since every column is
+/// identical, ShiftRows leaves column 0 unchanged, so lane 0 of the result is
+/// exactly `SubBytes(word)`.
+#[inline]
+unsafe fn sub_word(input: u32) -> u32 {
+    let input = vreinterpretq_u8_u32(vdupq_n_u32(input));
+    let sub = vaeseq_u8(input, vdupq_n_u8(0));
+    vgetq_lane_u32(vreinterpretq_u32_u8(sub), 0)
+}
+
+/// Standard Rijndael key expansion into `N` encryption round keys.
+///
+/// `L` is the key length in bytes (16 for AES-128, 32 for AES-256) and `N` is
+/// the number of round keys (11 for AES-128, 15 for AES-256).
+unsafe fn expand_key_encryption<const L: usize, const N: usize>(key: &[u8; L]) -> [uint8x16_t; N] {
+    /// There are 4 AES words (columns) in a block.
+    const BLOCK_WORDS: usize = 4;
+    /// An AES (Rijndael) word is always 32 bits / 4 bytes.
+    const WORD_SIZE: usize = 4;
+
+    let mut keys: [uint8x16_t; N] = mem::zeroed();
+
+    // The round keys are laid out as native-endian 32-bit columns; casting the
+    // 16-byte-aligned key array to `*mut u32` is sound.
+    let cols_ptr: *mut u32 = keys.as_mut_ptr().cast();
+    let columns = core::slice::from_raw_parts_mut(cols_ptr, N * BLOCK_WORDS);
+
+    for (i, chunk) in key.chunks_exact(WORD_SIZE).enumerate() {
+        columns[i] = u32::from_ne_bytes(chunk.try_into().unwrap());
+    }
+
+    // `Nk`: number of columns in the cipher key.
+    let nk = L / WORD_SIZE;
+    for i in nk..(N * BLOCK_WORDS) {
+        let mut word = columns[i - 1];
+        if i % nk == 0 {
+            word = sub_word(word).rotate_right(8) ^ ROUND_CONSTS[i / nk - 1];
+        } else if nk > 6 && i % nk == 4 {
+            word = sub_word(word);
+        }
+        columns[i] = columns[i - nk] ^ word;
+    }
+
+    keys
+}
+
+/// Derive the `N` decryption round keys from the encryption round keys.
+///
+/// This is the reverse of the encryption keys, with InvMixColumns applied to
+/// all but the first and last, matching the equivalent inverse cipher.
+unsafe fn expand_key_decryption<const N: usize>(keys: &[uint8x16_t; N]) -> [uint8x16_t; N] {
+    let mut inv: [uint8x16_t; N] = mem::zeroed();
+    inv[0] = keys[N - 1];
+    for i in 1..(N - 1) {
+        inv[i] = vaesimcq_u8(keys[N - 1 - i]);
+    }
+    inv[N - 1] = keys[0];
+    inv
+}
+
+pub(super) fn key_schedule128(key: &[u8; 16]) -> RoundKeys128 {
+    unsafe {
+        let enc = expand_key_encryption::<16, 11>(key);
+        let dec = expand_key_decryption::<11>(&enc);
+        RoundKeys128 { enc, dec }
+    }
+}
+
+pub(super) fn encrypt128(rkeys: &RoundKeys128, block: &[u8; 16]) -> [u8; 16] {
+    unsafe {
+        let mut b = vld1q_u8(block.as_ptr());
+        // Rounds 1..=9: AddRoundKey + SubBytes + ShiftRows, then MixColumns.
+        for &key in &rkeys.enc[..9] {
+            b = vaeseq_u8(b, key);
+            b = vaesmcq_u8(b);
+        }
+        // Round 10: no MixColumns, followed by the final AddRoundKey.
+        b = vaeseq_u8(b, rkeys.enc[9]);
+        b = veorq_u8(b, rkeys.enc[10]);
+
+        let mut out = [0u8; 16];
+        vst1q_u8(out.as_mut_ptr(), b);
+        out
+    }
+}
+
+pub(super) fn decrypt128(rkeys: &RoundKeys128, block: &[u8; 16]) -> [u8; 16] {
+    unsafe {
+        let mut b = vld1q_u8(block.as_ptr());
+        // Rounds 1..=9: AddRoundKey + InvShiftRows + InvSubBytes, then InvMixColumns.
+        for &key in &rkeys.dec[..9] {
+            b = vaesdq_u8(b, key);
+            b = vaesimcq_u8(b);
+        }
+        // Round 10: no InvMixColumns, followed by the final AddRoundKey.
+        b = vaesdq_u8(b, rkeys.dec[9]);
+        b = veorq_u8(b, rkeys.dec[10]);
+
+        let mut out = [0u8; 16];
+        vst1q_u8(out.as_mut_ptr(), b);
+        out
+    }
+}
+
+pub(super) fn key_schedule256(key: &[u8; 32]) -> RoundKeys256 {
+    unsafe {
+        let enc = expand_key_encryption::<32, 15>(key);
+        let dec = expand_key_decryption::<15>(&enc);
+        RoundKeys256 { enc, dec }
+    }
+}
+
+pub(super) fn encrypt256(rkeys: &RoundKeys256, block: &[u8; 16]) -> [u8; 16] {
+    unsafe {
+        let mut b = vld1q_u8(block.as_ptr());
+        // Rounds 1..=13: AddRoundKey + SubBytes + ShiftRows, then MixColumns.
+        for &key in &rkeys.enc[..13] {
+            b = vaeseq_u8(b, key);
+            b = vaesmcq_u8(b);
+        }
+        // Round 14: no MixColumns, followed by the final AddRoundKey.
+        b = vaeseq_u8(b, rkeys.enc[13]);
+        b = veorq_u8(b, rkeys.enc[14]);
+
+        let mut out = [0u8; 16];
+        vst1q_u8(out.as_mut_ptr(), b);
+        out
+    }
+}
+
+pub(super) fn decrypt256(rkeys: &RoundKeys256, block: &[u8; 16]) -> [u8; 16] {
+    unsafe {
+        let mut b = vld1q_u8(block.as_ptr());
+        // Rounds 1..=13: AddRoundKey + InvShiftRows + InvSubBytes, then InvMixColumns.
+        for &key in &rkeys.dec[..13] {
+            b = vaesdq_u8(b, key);
+            b = vaesimcq_u8(b);
+        }
+        // Round 14: no InvMixColumns, followed by the final AddRoundKey.
+        b = vaesdq_u8(b, rkeys.dec[13]);
+        b = veorq_u8(b, rkeys.dec[14]);
+
+        let mut out = [0u8; 16];
+        vst1q_u8(out.as_mut_ptr(), b);
+        out
+    }
+}

--- a/src/aes/mod.rs
+++ b/src/aes/mod.rs
@@ -1,0 +1,233 @@
+//! AES Block Cipher
+//!
+//! AES-128 and AES-256 implementation providing single-block encrypt and
+//! decrypt operations.
+//!
+//! The backend is selected at compile time:
+//!
+//! * On aarch64 with the `aes` target feature, the ARMv8 Cryptography
+//!   Extensions (hardware AES instructions) are used.
+//! * Otherwise, a portable, constant-time software implementation using the
+//!   fixsliced bitslice technique (Adomnicai & Peyrin, 2020) is used.
+//!
+//! # Note on use
+//!
+//! AES block cipher should be used with either some kind of block modes or as part
+//! of another construction. it is not recommeded to use as is, and should always
+//! be part of a high level construct (e.g. AES-GCM, AES-CTR).
+//!
+//! AES192 is omitted from this implementation, if need arise, submit a PR.
+//!
+//! # Example
+//!
+//! ```
+//! use cryptoxide::aes::Aes128;
+//!
+//! let key = [0u8; 16];
+//! let cipher = Aes128::new(&key);
+//! let plaintext = [0u8; 16];
+//! let ciphertext = cipher.encrypt_block(&plaintext);
+//! let recovered = cipher.decrypt_block(&ciphertext);
+//! assert_eq!(plaintext, recovered);
+//! ```
+
+// Hardware backend: ARMv8 Cryptography Extensions.
+#[cfg(all(target_arch = "aarch64", target_feature = "aes"))]
+mod aarch64;
+#[cfg(all(target_arch = "aarch64", target_feature = "aes"))]
+use aarch64 as backend;
+
+// Software backend: portable constant-time fixslice implementation.
+#[cfg(not(all(target_arch = "aarch64", target_feature = "aes")))]
+mod reference;
+#[cfg(not(all(target_arch = "aarch64", target_feature = "aes")))]
+use reference as backend;
+
+/// AES-128 block cipher with pre-expanded round keys.
+///
+/// Created from a 128-bit key via [`Aes128::new`]. The key schedule is
+/// computed once at construction time, making subsequent encrypt/decrypt
+/// operations fast.
+///
+/// The expanded round keys are stored in a backend-specific format and are
+/// used for both encryption and decryption.
+#[derive(Clone)]
+pub struct Aes128 {
+    round_keys: backend::RoundKeys128,
+}
+
+impl Aes128 {
+    /// Create a new AES-128 cipher from a 128-bit key.
+    ///
+    /// Performs key schedule expansion at construction time.
+    /// The resulting cipher can be reused for multiple encrypt/decrypt operations.
+    pub fn new(key: &[u8; 16]) -> Self {
+        Self {
+            round_keys: backend::key_schedule128(key),
+        }
+    }
+
+    /// Encrypt a single 128-bit block.
+    pub fn encrypt_block(&self, input: &[u8; 16]) -> [u8; 16] {
+        backend::encrypt128(&self.round_keys, input)
+    }
+
+    /// Decrypt a single 128-bit block.
+    pub fn decrypt_block(&self, input: &[u8; 16]) -> [u8; 16] {
+        backend::decrypt128(&self.round_keys, input)
+    }
+}
+
+/// AES-256 block cipher with pre-expanded round keys.
+///
+/// Created from a 256-bit key via [`Aes256::new`]. The key schedule is
+/// computed once at construction time, making subsequent encrypt/decrypt
+/// operations fast.
+///
+/// The expanded round keys are stored in a backend-specific format and are
+/// used for both encryption and decryption.
+#[derive(Clone)]
+pub struct Aes256 {
+    round_keys: backend::RoundKeys256,
+}
+
+impl Aes256 {
+    /// Create a new AES-256 cipher from a 256-bit key.
+    ///
+    /// Performs key schedule expansion at construction time.
+    /// The resulting cipher can be reused for multiple encrypt/decrypt operations.
+    pub fn new(key: &[u8; 32]) -> Self {
+        Self {
+            round_keys: backend::key_schedule256(key),
+        }
+    }
+
+    /// Encrypt a single 128-bit block.
+    pub fn encrypt_block(&self, input: &[u8; 16]) -> [u8; 16] {
+        backend::encrypt256(&self.round_keys, input)
+    }
+
+    /// Decrypt a single 128-bit block.
+    pub fn decrypt_block(&self, input: &[u8; 16]) -> [u8; 16] {
+        backend::decrypt256(&self.round_keys, input)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    // NIST FIPS 197 Appendix C.1 -- AES-128
+    #[test]
+    fn test_aes128_fips197_appendix_c() {
+        let key: [u8; 16] = [
+            0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d,
+            0x0e, 0x0f,
+        ];
+        let plaintext: [u8; 16] = [
+            0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd,
+            0xee, 0xff,
+        ];
+        let expected_ct: [u8; 16] = [
+            0x69, 0xc4, 0xe0, 0xd8, 0x6a, 0x7b, 0x04, 0x30, 0xd8, 0xcd, 0xb7, 0x80, 0x70, 0xb4,
+            0xc5, 0x5a,
+        ];
+        let cipher = Aes128::new(&key);
+        let ct = cipher.encrypt_block(&plaintext);
+        assert_eq!(ct, expected_ct, "AES-128 encrypt failed (FIPS 197 C.1)");
+        let pt = cipher.decrypt_block(&expected_ct);
+        assert_eq!(pt, plaintext, "AES-128 decrypt failed (FIPS 197 C.1)");
+    }
+
+    // NIST FIPS 197 Appendix C.3 -- AES-256
+    #[test]
+    fn test_aes256_fips197_appendix_c() {
+        let key: [u8; 32] = [
+            0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d,
+            0x0e, 0x0f, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1a, 0x1b,
+            0x1c, 0x1d, 0x1e, 0x1f,
+        ];
+        let plaintext: [u8; 16] = [
+            0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd,
+            0xee, 0xff,
+        ];
+        let expected_ct: [u8; 16] = [
+            0x8e, 0xa2, 0xb7, 0xca, 0x51, 0x67, 0x45, 0xbf, 0xea, 0xfc, 0x49, 0x90, 0x4b, 0x49,
+            0x60, 0x89,
+        ];
+        let cipher = Aes256::new(&key);
+        let ct = cipher.encrypt_block(&plaintext);
+        assert_eq!(ct, expected_ct, "AES-256 encrypt failed (FIPS 197 C.3)");
+        let pt = cipher.decrypt_block(&expected_ct);
+        assert_eq!(pt, plaintext, "AES-256 decrypt failed (FIPS 197 C.3)");
+    }
+
+    // NIST Known Answer Test -- zero key, zero plaintext
+    #[test]
+    fn test_aes128_zero_key_zero_plaintext() {
+        let key = [0u8; 16];
+        let plaintext = [0u8; 16];
+        let expected_ct: [u8; 16] = [
+            0x66, 0xe9, 0x4b, 0xd4, 0xef, 0x8a, 0x2c, 0x3b, 0x88, 0x4c, 0xfa, 0x59, 0xca, 0x34,
+            0x2b, 0x2e,
+        ];
+        let cipher = Aes128::new(&key);
+        let ct = cipher.encrypt_block(&plaintext);
+        assert_eq!(ct, expected_ct, "AES-128 zero-key KAT failed");
+        let pt = cipher.decrypt_block(&ct);
+        assert_eq!(pt, plaintext, "AES-128 zero-key decrypt round-trip failed");
+    }
+
+    #[test]
+    fn test_aes256_zero_key_zero_plaintext() {
+        let key = [0u8; 32];
+        let plaintext = [0u8; 16];
+        let expected_ct: [u8; 16] = [
+            0xdc, 0x95, 0xc0, 0x78, 0xa2, 0x40, 0x89, 0x89, 0xad, 0x48, 0xa2, 0x14, 0x92, 0x84,
+            0x20, 0x87,
+        ];
+        let cipher = Aes256::new(&key);
+        let ct = cipher.encrypt_block(&plaintext);
+        assert_eq!(ct, expected_ct, "AES-256 zero-key KAT failed");
+        let pt = cipher.decrypt_block(&ct);
+        assert_eq!(pt, plaintext, "AES-256 zero-key decrypt round-trip failed");
+    }
+
+    // Round-trip: encrypt then decrypt, and decrypt then encrypt
+    #[test]
+    fn test_aes128_round_trip() {
+        let key: [u8; 16] = [
+            0x2b, 0x7e, 0x15, 0x16, 0x28, 0xae, 0xd2, 0xa6, 0xab, 0xf7, 0x15, 0x88, 0x09, 0xcf,
+            0x4f, 0x3c,
+        ];
+        let plaintext: [u8; 16] = [
+            0x32, 0x43, 0xf6, 0xa8, 0x88, 0x5a, 0x30, 0x8d, 0x31, 0x31, 0x98, 0xa2, 0xe0, 0x37,
+            0x07, 0x34,
+        ];
+        let cipher = Aes128::new(&key);
+        let ct = cipher.encrypt_block(&plaintext);
+        let recovered = cipher.decrypt_block(&ct);
+        assert_eq!(recovered, plaintext, "AES-128 round-trip failed");
+        let ct2 = cipher.encrypt_block(&recovered);
+        assert_eq!(ct2, ct, "AES-128 reverse round-trip failed");
+    }
+
+    #[test]
+    fn test_aes256_round_trip() {
+        let key: [u8; 32] = [
+            0x60, 0x3d, 0xeb, 0x10, 0x15, 0xca, 0x71, 0xbe, 0x2b, 0x73, 0xae, 0xf0, 0x85, 0x7d,
+            0x77, 0x81, 0x1f, 0x35, 0x2c, 0x07, 0x3b, 0x61, 0x08, 0xd7, 0x2d, 0x98, 0x10, 0xa3,
+            0x09, 0x14, 0xdf, 0xf4,
+        ];
+        let plaintext: [u8; 16] = [
+            0x6b, 0xc1, 0xbe, 0xe2, 0x2e, 0x40, 0x9f, 0x96, 0xe9, 0x3d, 0x7e, 0x11, 0x73, 0x93,
+            0x17, 0x2a,
+        ];
+        let cipher = Aes256::new(&key);
+        let ct = cipher.encrypt_block(&plaintext);
+        let recovered = cipher.decrypt_block(&ct);
+        assert_eq!(recovered, plaintext, "AES-256 round-trip failed");
+        let ct2 = cipher.encrypt_block(&recovered);
+        assert_eq!(ct2, ct, "AES-256 reverse round-trip failed");
+    }
+}

--- a/src/aes/reference.rs
+++ b/src/aes/reference.rs
@@ -1,0 +1,1041 @@
+//! Software (reference) AES backend.
+//!
+//! Constant-time, table-free AES-128 and AES-256 using the fixsliced bitslice
+//! technique (Adomnicai & Peyrin, 2020). The state is represented as 8 x u64
+//! registers (a 512-bit state holding four interleaved blocks), SubBytes uses
+//! the Boyar-Peralta boolean circuit (113 gates), and four MixColumns rotation
+//! variants eliminate the need for explicit ShiftRows during rounds.
+//!
+//! No lookup tables are used. All operations are bitwise arithmetic on u64
+//! registers, providing constant-time execution on all platforms.
+//!
+//! Some code parts are directly borrowed with adaption from the RustCrypto
+//! AES implementation (also borrowing bits too).
+//!
+//! See [Fixslicing AES like ciphers](https://eprint.iacr.org/2020/1123.pdf) and
+//! [Circuit Minimisation Team](http://www.cs.yale.edu/homes/peralta/CircuitStuff/CMT.html)
+
+#![allow(clippy::unreadable_literal)]
+
+/// AES-128 fixsliced round keys (11 round keys x 8 u64 registers).
+#[derive(Clone)]
+pub(super) struct RoundKeys128([u64; 88]);
+
+/// AES-256 fixsliced round keys (15 round keys x 8 u64 registers).
+#[derive(Clone)]
+pub(super) struct RoundKeys256([u64; 120]);
+
+impl Drop for RoundKeys128 {
+    fn drop(&mut self) {
+        self.0.iter_mut().for_each(|v| *v = 0);
+    }
+}
+
+impl Drop for RoundKeys256 {
+    fn drop(&mut self) {
+        self.0.iter_mut().for_each(|v| *v = 0);
+    }
+}
+
+#[inline(always)]
+fn delta_swap_1(a: &mut u64, shift: u32, mask: u64) {
+    let t = (*a ^ (*a >> shift)) & mask;
+    *a ^= t ^ (t << shift);
+}
+
+#[inline(always)]
+fn delta_swap_2(a: &mut u64, b: &mut u64, shift: u32, mask: u64) {
+    let t = (*a ^ (*b >> shift)) & mask;
+    *a ^= t;
+    *b ^= t << shift;
+}
+
+#[inline(always)]
+fn ror(x: u64, y: u32) -> u64 {
+    x.rotate_right(y)
+}
+
+#[inline(always)]
+fn ror_distance(rows: u32, cols: u32) -> u32 {
+    (rows << 4) + (cols << 2)
+}
+
+#[inline(always)]
+fn rotate_rows_1(x: u64) -> u64 {
+    ror(x, ror_distance(1, 0))
+}
+
+#[inline(always)]
+fn rotate_rows_2(x: u64) -> u64 {
+    ror(x, ror_distance(2, 0))
+}
+
+#[inline(always)]
+#[rustfmt::skip]
+fn rotate_rows_and_columns_1_1(x: u64) -> u64 {
+    (ror(x, ror_distance(1, 1)) & 0x0fff0fff0fff0fff) |
+    (ror(x, ror_distance(0, 1)) & 0xf000f000f000f000)
+}
+
+#[inline(always)]
+#[rustfmt::skip]
+fn rotate_rows_and_columns_1_2(x: u64) -> u64 {
+    (ror(x, ror_distance(1, 2)) & 0x00ff00ff00ff00ff) |
+    (ror(x, ror_distance(0, 2)) & 0xff00ff00ff00ff00)
+}
+
+#[inline(always)]
+#[rustfmt::skip]
+fn rotate_rows_and_columns_1_3(x: u64) -> u64 {
+    (ror(x, ror_distance(1, 3)) & 0x000f000f000f000f) |
+    (ror(x, ror_distance(0, 3)) & 0xfff0fff0fff0fff0)
+}
+
+#[inline(always)]
+#[rustfmt::skip]
+fn rotate_rows_and_columns_2_2(x: u64) -> u64 {
+    (ror(x, ror_distance(2, 2)) & 0x00ff00ff00ff00ff) |
+    (ror(x, ror_distance(1, 2)) & 0xff00ff00ff00ff00)
+}
+
+/// Pack four 16-byte blocks into the bitsliced representation ([u64; 8]).
+fn bitslice(output: &mut [u64], input0: &[u8], input1: &[u8], input2: &[u8], input3: &[u8]) {
+    debug_assert!(output.len() >= 8);
+    debug_assert!(input0.len() >= 16);
+    debug_assert!(input1.len() >= 16);
+    debug_assert!(input2.len() >= 16);
+    debug_assert!(input3.len() >= 16);
+
+    // Bitslicing is a bit index manipulation. 512 bits of data means each bit is positioned at a
+    // 9-bit index. AES data is 4 blocks, each one a 4x4 column-major matrix of bytes, so the
+    // index is initially ([b]lock, [c]olumn, [r]ow, [p]osition):
+    //     b1 b0 c1 c0 r1 r0 p2 p1 p0
+    //
+    // The desired bitsliced data groups first by bit position, then row, column, block:
+    //     p2 p1 p0 r1 r0 c1 c0 b1 b0
+
+    #[rustfmt::skip]
+    fn read_reordered(input: &[u8]) -> u64 {
+        (u64::from(input[0x0])        ) |
+        (u64::from(input[0x1]) << 0x10) |
+        (u64::from(input[0x2]) << 0x20) |
+        (u64::from(input[0x3]) << 0x30) |
+        (u64::from(input[0x8]) << 0x08) |
+        (u64::from(input[0x9]) << 0x18) |
+        (u64::from(input[0xa]) << 0x28) |
+        (u64::from(input[0xb]) << 0x38)
+    }
+
+    // Reorder each block's bytes on input
+    //     __ __ c1 c0 r1 r0 __ __ __ => __ __ c0 r1 r0 c1 __ __ __
+    // Reorder by relabeling (note the order of input)
+    //     b1 b0 c0 __ __ __ __ __ __ => c0 b1 b0 __ __ __ __ __ __
+    let mut t0 = read_reordered(&input0[0x00..0x0c]);
+    let mut t4 = read_reordered(&input0[0x04..0x10]);
+    let mut t1 = read_reordered(&input1[0x00..0x0c]);
+    let mut t5 = read_reordered(&input1[0x04..0x10]);
+    let mut t2 = read_reordered(&input2[0x00..0x0c]);
+    let mut t6 = read_reordered(&input2[0x04..0x10]);
+    let mut t3 = read_reordered(&input3[0x00..0x0c]);
+    let mut t7 = read_reordered(&input3[0x04..0x10]);
+
+    // Bit Index Swap 6 <-> 0:
+    //     __ __ b0 __ __ __ __ __ p0 => __ __ p0 __ __ __ __ __ b0
+    let m0 = 0x5555555555555555;
+    delta_swap_2(&mut t1, &mut t0, 1, m0);
+    delta_swap_2(&mut t3, &mut t2, 1, m0);
+    delta_swap_2(&mut t5, &mut t4, 1, m0);
+    delta_swap_2(&mut t7, &mut t6, 1, m0);
+
+    // Bit Index Swap 7 <-> 1:
+    //     __ b1 __ __ __ __ __ p1 __ => __ p1 __ __ __ __ __ b1 __
+    let m1 = 0x3333333333333333;
+    delta_swap_2(&mut t2, &mut t0, 2, m1);
+    delta_swap_2(&mut t3, &mut t1, 2, m1);
+    delta_swap_2(&mut t6, &mut t4, 2, m1);
+    delta_swap_2(&mut t7, &mut t5, 2, m1);
+
+    // Bit Index Swap 8 <-> 2:
+    //     c0 __ __ __ __ __ p2 __ __ => p2 __ __ __ __ __ c0 __ __
+    let m2 = 0x0f0f0f0f0f0f0f0f;
+    delta_swap_2(&mut t4, &mut t0, 4, m2);
+    delta_swap_2(&mut t5, &mut t1, 4, m2);
+    delta_swap_2(&mut t6, &mut t2, 4, m2);
+    delta_swap_2(&mut t7, &mut t3, 4, m2);
+
+    // Final bitsliced bit index, as desired:
+    //     p2 p1 p0 r1 r0 c1 c0 b1 b0
+    output[0] = t0;
+    output[1] = t1;
+    output[2] = t2;
+    output[3] = t3;
+    output[4] = t4;
+    output[5] = t5;
+    output[6] = t6;
+    output[7] = t7;
+}
+
+/// Unpack the bitsliced representation back to four 16-byte blocks.
+fn inv_bitslice(input: &[u64]) -> [[u8; 16]; 4] {
+    debug_assert!(input.len() >= 8);
+
+    let mut t0 = input[0];
+    let mut t1 = input[1];
+    let mut t2 = input[2];
+    let mut t3 = input[3];
+    let mut t4 = input[4];
+    let mut t5 = input[5];
+    let mut t6 = input[6];
+    let mut t7 = input[7];
+
+    // Bit Index Swap 6 <-> 0:
+    //     __ __ p0 __ __ __ __ __ b0 => __ __ b0 __ __ __ __ __ p0
+    let m0 = 0x5555555555555555;
+    delta_swap_2(&mut t1, &mut t0, 1, m0);
+    delta_swap_2(&mut t3, &mut t2, 1, m0);
+    delta_swap_2(&mut t5, &mut t4, 1, m0);
+    delta_swap_2(&mut t7, &mut t6, 1, m0);
+
+    // Bit Index Swap 7 <-> 1:
+    //     __ p1 __ __ __ __ __ b1 __ => __ b1 __ __ __ __ __ p1 __
+    let m1 = 0x3333333333333333;
+    delta_swap_2(&mut t2, &mut t0, 2, m1);
+    delta_swap_2(&mut t3, &mut t1, 2, m1);
+    delta_swap_2(&mut t6, &mut t4, 2, m1);
+    delta_swap_2(&mut t7, &mut t5, 2, m1);
+
+    // Bit Index Swap 8 <-> 2:
+    //     p2 __ __ __ __ __ c0 __ __ => c0 __ __ __ __ __ p2 __ __
+    let m2 = 0x0f0f0f0f0f0f0f0f;
+    delta_swap_2(&mut t4, &mut t0, 4, m2);
+    delta_swap_2(&mut t5, &mut t1, 4, m2);
+    delta_swap_2(&mut t6, &mut t2, 4, m2);
+    delta_swap_2(&mut t7, &mut t3, 4, m2);
+
+    #[rustfmt::skip]
+    fn write_reordered(columns: u64, output: &mut [u8]) {
+        output[0x0] = (columns        ) as u8;
+        output[0x1] = (columns >> 0x10) as u8;
+        output[0x2] = (columns >> 0x20) as u8;
+        output[0x3] = (columns >> 0x30) as u8;
+        output[0x8] = (columns >> 0x08) as u8;
+        output[0x9] = (columns >> 0x18) as u8;
+        output[0xa] = (columns >> 0x28) as u8;
+        output[0xb] = (columns >> 0x38) as u8;
+    }
+
+    let mut output = [[0u8; 16]; 4];
+    // Reorder by relabeling (note the order of output)
+    //     c0 b1 b0 __ __ __ __ __ __ => b1 b0 c0 __ __ __ __ __ __
+    // Reorder each block's bytes on output
+    //     __ __ c0 r1 r0 c1 __ __ __ => __ __ c1 c0 r1 r0 __ __ __
+    write_reordered(t0, &mut output[0][0x00..0x0c]);
+    write_reordered(t4, &mut output[0][0x04..0x10]);
+    write_reordered(t1, &mut output[1][0x00..0x0c]);
+    write_reordered(t5, &mut output[1][0x04..0x10]);
+    write_reordered(t2, &mut output[2][0x00..0x0c]);
+    write_reordered(t6, &mut output[2][0x04..0x10]);
+    write_reordered(t3, &mut output[3][0x00..0x0c]);
+    write_reordered(t7, &mut output[3][0x04..0x10]);
+
+    // Final AES bit index, as desired:
+    //     b1 b0 c1 c0 r1 r0 p2 p1 p0
+    output
+}
+
+/// Bitsliced AES S-box based on Boyar, Peralta and Calik.
+///
+/// See: <http://www.cs.yale.edu/homes/peralta/CircuitStuff/SLP_AES_113.txt>
+///
+/// Note that the 4 bitwise NOT operations are moved to the key schedule.
+fn sub_bytes(state: &mut [u64]) {
+    debug_assert!(state.len() >= 8);
+
+    let u7 = state[0];
+    let u6 = state[1];
+    let u5 = state[2];
+    let u4 = state[3];
+    let u3 = state[4];
+    let u2 = state[5];
+    let u1 = state[6];
+    let u0 = state[7];
+
+    let y14 = u3 ^ u5;
+    let y13 = u0 ^ u6;
+    let y12 = y13 ^ y14;
+    let t1 = u4 ^ y12;
+    let y15 = t1 ^ u5;
+    let t2 = y12 & y15;
+    let y6 = y15 ^ u7;
+    let y20 = t1 ^ u1;
+    let y9 = u0 ^ u3;
+    let y11 = y20 ^ y9;
+    let t12 = y9 & y11;
+    let y7 = u7 ^ y11;
+    let y8 = u0 ^ u5;
+    let t0 = u1 ^ u2;
+    let y10 = y15 ^ t0;
+    let y17 = y10 ^ y11;
+    let t13 = y14 & y17;
+    let t14 = t13 ^ t12;
+    let y19 = y10 ^ y8;
+    let t15 = y8 & y10;
+    let t16 = t15 ^ t12;
+    let y16 = t0 ^ y11;
+    let y21 = y13 ^ y16;
+    let t7 = y13 & y16;
+    let y18 = u0 ^ y16;
+    let y1 = t0 ^ u7;
+    let y4 = y1 ^ u3;
+    let t5 = y4 & u7;
+    let t6 = t5 ^ t2;
+    let t18 = t6 ^ t16;
+    let t22 = t18 ^ y19;
+    let y2 = y1 ^ u0;
+    let t10 = y2 & y7;
+    let t11 = t10 ^ t7;
+    let t20 = t11 ^ t16;
+    let t24 = t20 ^ y18;
+    let y5 = y1 ^ u6;
+    let t8 = y5 & y1;
+    let t9 = t8 ^ t7;
+    let t19 = t9 ^ t14;
+    let t23 = t19 ^ y21;
+    let y3 = y5 ^ y8;
+    let t3 = y3 & y6;
+    let t4 = t3 ^ t2;
+    let t17 = t4 ^ y20;
+    let t21 = t17 ^ t14;
+    let t26 = t21 & t23;
+    let t27 = t24 ^ t26;
+    let t31 = t22 ^ t26;
+    let t25 = t21 ^ t22;
+    let t28 = t25 & t27;
+    let t29 = t28 ^ t22;
+    let z14 = t29 & y2;
+    let z5 = t29 & y7;
+    let t30 = t23 ^ t24;
+    let t32 = t31 & t30;
+    let t33 = t32 ^ t24;
+    let t35 = t27 ^ t33;
+    let t36 = t24 & t35;
+    let t38 = t27 ^ t36;
+    let t39 = t29 & t38;
+    let t40 = t25 ^ t39;
+    let t43 = t29 ^ t40;
+    let z3 = t43 & y16;
+    let tc12 = z3 ^ z5;
+    let z12 = t43 & y13;
+    let z13 = t40 & y5;
+    let z4 = t40 & y1;
+    let tc6 = z3 ^ z4;
+    let t34 = t23 ^ t33;
+    let t37 = t36 ^ t34;
+    let t41 = t40 ^ t37;
+    let z8 = t41 & y10;
+    let z17 = t41 & y8;
+    let t44 = t33 ^ t37;
+    let z0 = t44 & y15;
+    let z9 = t44 & y12;
+    let z10 = t37 & y3;
+    let z1 = t37 & y6;
+    let tc5 = z1 ^ z0;
+    let tc11 = tc6 ^ tc5;
+    let z11 = t33 & y4;
+    let t42 = t29 ^ t33;
+    let t45 = t42 ^ t41;
+    let z7 = t45 & y17;
+    let tc8 = z7 ^ tc6;
+    let z16 = t45 & y14;
+    let z6 = t42 & y11;
+    let tc16 = z6 ^ tc8;
+    let z15 = t42 & y9;
+    let tc20 = z15 ^ tc16;
+    let tc1 = z15 ^ z16;
+    let tc2 = z10 ^ tc1;
+    let tc21 = tc2 ^ z11;
+    let tc3 = z9 ^ tc2;
+    let s0 = tc3 ^ tc16;
+    let s3 = tc3 ^ tc11;
+    let s1 = s3 ^ tc16;
+    let tc13 = z13 ^ tc1;
+    let z2 = t33 & u7;
+    let tc4 = z0 ^ z2;
+    let tc7 = z12 ^ tc4;
+    let tc9 = z8 ^ tc7;
+    let tc10 = tc8 ^ tc9;
+    let tc17 = z14 ^ tc10;
+    let s5 = tc21 ^ tc17;
+    let tc26 = tc17 ^ tc20;
+    let s2 = tc26 ^ z17;
+    let tc14 = tc4 ^ tc12;
+    let tc18 = tc13 ^ tc14;
+    let s6 = tc10 ^ tc18;
+    let s7 = z12 ^ tc18;
+    let s4 = tc14 ^ s3;
+
+    state[0] = s7;
+    state[1] = s6;
+    state[2] = s5;
+    state[3] = s4;
+    state[4] = s3;
+    state[5] = s2;
+    state[6] = s1;
+    state[7] = s0;
+}
+
+/// Note that the 4 bitwise NOT are accounted for here so that it is a true
+/// inverse of `sub_bytes`.
+fn inv_sub_bytes(state: &mut [u64]) {
+    debug_assert!(state.len() >= 8);
+
+    let u7 = state[0];
+    let u6 = state[1];
+    let u5 = state[2];
+    let u4 = state[3];
+    let u3 = state[4];
+    let u2 = state[5];
+    let u1 = state[6];
+    let u0 = state[7];
+
+    let t23 = u0 ^ u3;
+    let t8 = u1 ^ t23;
+    let m2 = t23 & t8;
+    let t4 = u4 ^ t8;
+    let t22 = u1 ^ u3;
+    let t2 = u0 ^ u1;
+    let t1 = u3 ^ u4;
+    let t9 = u7 ^ t1;
+    let m7 = t22 & t9;
+    let t24 = u4 ^ u7;
+    let t10 = t2 ^ t24;
+    let m14 = t2 & t10;
+    let r5 = u6 ^ u7;
+    let t3 = t1 ^ r5;
+    let t13 = t2 ^ r5;
+    let t19 = t22 ^ r5;
+    let t17 = u2 ^ t19;
+    let t25 = u2 ^ t1;
+    let r13 = u1 ^ u6;
+    let t20 = t24 ^ r13;
+    let m9 = t20 & t17;
+    let r17 = u2 ^ u5;
+    let t6 = t22 ^ r17;
+    let m1 = t13 & t6;
+    let y5 = u0 ^ r17;
+    let m4 = t19 & y5;
+    let m5 = m4 ^ m1;
+    let m17 = m5 ^ t24;
+    let r18 = u5 ^ u6;
+    let t27 = t1 ^ r18;
+    let t15 = t10 ^ t27;
+    let m11 = t1 & t15;
+    let m15 = m14 ^ m11;
+    let m21 = m17 ^ m15;
+    let m12 = t4 & t27;
+    let m13 = m12 ^ m11;
+    let t14 = t10 ^ r18;
+    let m3 = t14 ^ m1;
+    let m16 = m3 ^ m2;
+    let m20 = m16 ^ m13;
+    let r19 = u2 ^ u4;
+    let t16 = r13 ^ r19;
+    let t26 = t3 ^ t16;
+    let m6 = t3 & t16;
+    let m8 = t26 ^ m6;
+    let m18 = m8 ^ m7;
+    let m22 = m18 ^ m13;
+    let m25 = m22 & m20;
+    let m26 = m21 ^ m25;
+    let m10 = m9 ^ m6;
+    let m19 = m10 ^ m15;
+    let m23 = m19 ^ t25;
+    let m28 = m23 ^ m25;
+    let m24 = m22 ^ m23;
+    let m30 = m26 & m24;
+    let m39 = m23 ^ m30;
+    let m48 = m39 & y5;
+    let m57 = m39 & t19;
+    let m36 = m24 ^ m25;
+    let m31 = m20 & m23;
+    let m27 = m20 ^ m21;
+    let m32 = m27 & m31;
+    let m29 = m28 & m27;
+    let m37 = m21 ^ m29;
+    let m42 = m37 ^ m39;
+    let m52 = m42 & t15;
+    let m61 = m42 & t1;
+    let p0 = m52 ^ m61;
+    let p16 = m57 ^ m61;
+    let m60 = m37 & t20;
+    let m51 = m37 & t17;
+    let m33 = m27 ^ m25;
+    let m38 = m32 ^ m33;
+    let m43 = m37 ^ m38;
+    let m49 = m43 & t16;
+    let p6 = m49 ^ m60;
+    let p13 = m49 ^ m51;
+    let m58 = m43 & t3;
+    let m50 = m38 & t9;
+    let m59 = m38 & t22;
+    let p1 = m58 ^ m59;
+    let p7 = p0 ^ p1;
+    let m34 = m21 & m22;
+    let m35 = m24 & m34;
+    let m40 = m35 ^ m36;
+    let m41 = m38 ^ m40;
+    let m45 = m42 ^ m41;
+    let m53 = m45 & t27;
+    let p8 = m50 ^ m53;
+    let p23 = p7 ^ p8;
+    let m62 = m45 & t4;
+    let p14 = m49 ^ m62;
+    let s6 = p14 ^ p23;
+    let m54 = m41 & t10;
+    let p2 = m54 ^ m62;
+    let p22 = p2 ^ p7;
+    let s0 = p13 ^ p22;
+    let p17 = m58 ^ p2;
+    let p15 = m54 ^ m59;
+    let m63 = m41 & t2;
+    let m44 = m39 ^ m40;
+    let m46 = m44 & t6;
+    let p5 = m46 ^ m51;
+    let p18 = m63 ^ p5;
+    let p24 = p5 ^ p7;
+    let p12 = m46 ^ m48;
+    let s3 = p12 ^ p22;
+    let m55 = m44 & t13;
+    let p9 = m55 ^ m63;
+    let s7 = p9 ^ p16;
+    let m47 = m40 & t8;
+    let p3 = m47 ^ m50;
+    let p19 = p2 ^ p3;
+    let s5 = p19 ^ p24;
+    let p11 = p0 ^ p3;
+    let p26 = p9 ^ p11;
+    let m56 = m40 & t23;
+    let p4 = m48 ^ m56;
+    let p20 = p4 ^ p6;
+    let p29 = p15 ^ p20;
+    let s1 = p26 ^ p29;
+    let p10 = m57 ^ p4;
+    let p27 = p10 ^ p18;
+    let s4 = p23 ^ p27;
+    let p25 = p6 ^ p10;
+    let p28 = p11 ^ p25;
+    let s2 = p17 ^ p28;
+
+    state[0] = s7;
+    state[1] = s6;
+    state[2] = s5;
+    state[3] = s4;
+    state[4] = s3;
+    state[5] = s2;
+    state[6] = s1;
+    state[7] = s0;
+}
+
+/// NOT operations that are omitted in the S-box and folded into the key schedule.
+#[inline]
+fn sub_bytes_nots(state: &mut [u64]) {
+    debug_assert!(state.len() >= 8);
+    state[0] ^= 0xffffffffffffffff;
+    state[1] ^= 0xffffffffffffffff;
+    state[5] ^= 0xffffffffffffffff;
+    state[6] ^= 0xffffffffffffffff;
+}
+
+// MixColumns — 4 rotation variants
+macro_rules! define_mix_columns {
+    (
+        $name:ident,
+        $name_inv:ident,
+        $first_rotate:path,
+        $second_rotate:path
+    ) => {
+        fn $name(state: &mut [u64]) {
+            let (a0, a1, a2, a3, a4, a5, a6, a7) = (
+                state[0], state[1], state[2], state[3], state[4], state[5], state[6], state[7],
+            );
+            let (b0, b1, b2, b3, b4, b5, b6, b7) = (
+                $first_rotate(a0),
+                $first_rotate(a1),
+                $first_rotate(a2),
+                $first_rotate(a3),
+                $first_rotate(a4),
+                $first_rotate(a5),
+                $first_rotate(a6),
+                $first_rotate(a7),
+            );
+            let (c0, c1, c2, c3, c4, c5, c6, c7) = (
+                a0 ^ b0,
+                a1 ^ b1,
+                a2 ^ b2,
+                a3 ^ b3,
+                a4 ^ b4,
+                a5 ^ b5,
+                a6 ^ b6,
+                a7 ^ b7,
+            );
+            state[0] = b0 ^ c7 ^ $second_rotate(c0);
+            state[1] = b1 ^ c0 ^ c7 ^ $second_rotate(c1);
+            state[2] = b2 ^ c1 ^ $second_rotate(c2);
+            state[3] = b3 ^ c2 ^ c7 ^ $second_rotate(c3);
+            state[4] = b4 ^ c3 ^ c7 ^ $second_rotate(c4);
+            state[5] = b5 ^ c4 ^ $second_rotate(c5);
+            state[6] = b6 ^ c5 ^ $second_rotate(c6);
+            state[7] = b7 ^ c6 ^ $second_rotate(c7);
+        }
+
+        fn $name_inv(state: &mut [u64]) {
+            let (a0, a1, a2, a3, a4, a5, a6, a7) = (
+                state[0], state[1], state[2], state[3], state[4], state[5], state[6], state[7],
+            );
+            let (b0, b1, b2, b3, b4, b5, b6, b7) = (
+                $first_rotate(a0),
+                $first_rotate(a1),
+                $first_rotate(a2),
+                $first_rotate(a3),
+                $first_rotate(a4),
+                $first_rotate(a5),
+                $first_rotate(a6),
+                $first_rotate(a7),
+            );
+            let (c0, c1, c2, c3, c4, c5, c6, c7) = (
+                a0 ^ b0,
+                a1 ^ b1,
+                a2 ^ b2,
+                a3 ^ b3,
+                a4 ^ b4,
+                a5 ^ b5,
+                a6 ^ b6,
+                a7 ^ b7,
+            );
+            let (d0, d1, d2, d3, d4, d5, d6, d7) = (
+                a0 ^ c7,
+                a1 ^ c0 ^ c7,
+                a2 ^ c1,
+                a3 ^ c2 ^ c7,
+                a4 ^ c3 ^ c7,
+                a5 ^ c4,
+                a6 ^ c5,
+                a7 ^ c6,
+            );
+            let (e0, e1, e2, e3, e4, e5, e6, e7) = (
+                c0 ^ d6,
+                c1 ^ d6 ^ d7,
+                c2 ^ d0 ^ d7,
+                c3 ^ d1 ^ d6,
+                c4 ^ d2 ^ d6 ^ d7,
+                c5 ^ d3 ^ d7,
+                c6 ^ d4,
+                c7 ^ d5,
+            );
+            state[0] = d0 ^ e0 ^ $second_rotate(e0);
+            state[1] = d1 ^ e1 ^ $second_rotate(e1);
+            state[2] = d2 ^ e2 ^ $second_rotate(e2);
+            state[3] = d3 ^ e3 ^ $second_rotate(e3);
+            state[4] = d4 ^ e4 ^ $second_rotate(e4);
+            state[5] = d5 ^ e5 ^ $second_rotate(e5);
+            state[6] = d6 ^ e6 ^ $second_rotate(e6);
+            state[7] = d7 ^ e7 ^ $second_rotate(e7);
+        }
+    };
+}
+
+define_mix_columns!(
+    mix_columns_0,
+    inv_mix_columns_0,
+    rotate_rows_1,
+    rotate_rows_2
+);
+
+define_mix_columns!(
+    mix_columns_1,
+    inv_mix_columns_1,
+    rotate_rows_and_columns_1_1,
+    rotate_rows_and_columns_2_2
+);
+
+define_mix_columns!(
+    mix_columns_2,
+    inv_mix_columns_2,
+    rotate_rows_and_columns_1_2,
+    rotate_rows_2
+);
+
+define_mix_columns!(
+    mix_columns_3,
+    inv_mix_columns_3,
+    rotate_rows_and_columns_1_3,
+    rotate_rows_and_columns_2_2
+);
+
+#[inline]
+fn shift_rows_1(state: &mut [u64]) {
+    debug_assert!(state.len() >= 8);
+    for x in state.iter_mut().take(8) {
+        delta_swap_1(x, 8, 0x00f000ff000f0000);
+        delta_swap_1(x, 4, 0x0f0f00000f0f0000);
+    }
+}
+
+#[inline]
+fn shift_rows_2(state: &mut [u64]) {
+    debug_assert!(state.len() >= 8);
+    for x in state.iter_mut().take(8) {
+        delta_swap_1(x, 8, 0x00ff000000ff0000);
+    }
+}
+
+#[inline]
+fn shift_rows_3(state: &mut [u64]) {
+    debug_assert!(state.len() >= 8);
+    for x in state.iter_mut().take(8) {
+        delta_swap_1(x, 8, 0x000f00ff00f00000);
+        delta_swap_1(x, 4, 0x0f0f00000f0f0000);
+    }
+}
+
+#[inline(always)]
+fn inv_shift_rows_1(state: &mut [u64]) {
+    shift_rows_3(state);
+}
+
+#[inline(always)]
+fn inv_shift_rows_2(state: &mut [u64]) {
+    shift_rows_2(state);
+}
+
+#[inline(always)]
+fn inv_shift_rows_3(state: &mut [u64]) {
+    shift_rows_1(state);
+}
+
+/// Copy 8 u64 values forward by 8 positions within `buffer`.
+fn memshift32(buffer: &mut [u64], src_offset: usize) {
+    debug_assert!(src_offset % 8 == 0);
+    let dst_offset = src_offset + 8;
+    debug_assert!(dst_offset + 8 <= buffer.len());
+    for i in (0..8).rev() {
+        buffer[dst_offset + i] = buffer[src_offset + i];
+    }
+}
+
+/// XOR a round key into the state.
+#[inline(always)]
+fn add_round_key(state: &mut [u64; 8], rkey: &[u64]) {
+    debug_assert!(rkey.len() >= 8);
+    for (a, b) in state.iter_mut().zip(rkey.iter()) {
+        *a ^= b;
+    }
+}
+
+/// XOR the constant 0x00000000f0000000 into a specific bit register.
+#[inline(always)]
+fn add_round_constant_bit(state: &mut [u64], bit: usize) {
+    state[bit] ^= 0x00000000f0000000;
+}
+
+/// XOR columns in the key schedule with rotation for Rcon application.
+fn xor_columns(rkeys: &mut [u64], offset: usize, idx_xor: usize, idx_ror: u32) {
+    for i in 0..8 {
+        let off_i = offset + i;
+        let rk = rkeys[off_i - idx_xor] ^ (0x000f000f000f000f & ror(rkeys[off_i], idx_ror));
+        rkeys[off_i] = rk
+            ^ (0xfff0fff0fff0fff0 & (rk << 4))
+            ^ (0xff00ff00ff00ff00 & (rk << 8))
+            ^ (0xf000f000f000f000 & (rk << 12));
+    }
+}
+
+// ----------------------------------------------------------------
+// AES-128 key schedule
+// ----------------------------------------------------------------
+
+/// Expand an AES-128 key into fixsliced round keys.
+///
+/// Returns 88 u64 values (11 round keys x 8 registers each) in the fixsliced
+/// representation. The same keys are used for both encryption and decryption.
+pub(super) fn key_schedule128(key: &[u8; 16]) -> RoundKeys128 {
+    let mut rkeys = [0u64; 88];
+
+    bitslice(&mut rkeys[..8], key, key, key, key);
+
+    let mut rk_off = 0;
+    for rcon in 0..10 {
+        memshift32(&mut rkeys, rk_off);
+        rk_off += 8;
+
+        sub_bytes(&mut rkeys[rk_off..(rk_off + 8)]);
+        sub_bytes_nots(&mut rkeys[rk_off..(rk_off + 8)]);
+
+        if rcon < 8 {
+            add_round_constant_bit(&mut rkeys[rk_off..(rk_off + 8)], rcon);
+        } else {
+            add_round_constant_bit(&mut rkeys[rk_off..(rk_off + 8)], rcon - 8);
+            add_round_constant_bit(&mut rkeys[rk_off..(rk_off + 8)], rcon - 7);
+            add_round_constant_bit(&mut rkeys[rk_off..(rk_off + 8)], rcon - 5);
+            add_round_constant_bit(&mut rkeys[rk_off..(rk_off + 8)], rcon - 4);
+        }
+
+        xor_columns(&mut rkeys, rk_off, 8, ror_distance(1, 3));
+    }
+
+    // Adjust to match fixslicing format (non-compact)
+    for i in (8..72).step_by(32) {
+        inv_shift_rows_1(&mut rkeys[i..(i + 8)]);
+        inv_shift_rows_2(&mut rkeys[(i + 8)..(i + 16)]);
+        inv_shift_rows_3(&mut rkeys[(i + 16)..(i + 24)]);
+    }
+    inv_shift_rows_1(&mut rkeys[72..80]);
+
+    // Account for NOTs removed from sub_bytes
+    for i in 1..11 {
+        sub_bytes_nots(&mut rkeys[(i * 8)..(i * 8 + 8)]);
+    }
+
+    RoundKeys128(rkeys)
+}
+
+/// Expand an AES-256 key into fixsliced round keys.
+///
+/// Returns 120 u64 values (15 round keys x 8 registers each) in the fixsliced
+/// representation. The same keys are used for both encryption and decryption.
+pub(super) fn key_schedule256(key: &[u8; 32]) -> RoundKeys256 {
+    let mut rkeys = [0u64; 120];
+
+    bitslice(
+        &mut rkeys[..8],
+        &key[..16],
+        &key[..16],
+        &key[..16],
+        &key[..16],
+    );
+    bitslice(
+        &mut rkeys[8..16],
+        &key[16..],
+        &key[16..],
+        &key[16..],
+        &key[16..],
+    );
+
+    let mut rk_off = 8;
+
+    let mut rcon = 0;
+    loop {
+        memshift32(&mut rkeys, rk_off);
+        rk_off += 8;
+
+        sub_bytes(&mut rkeys[rk_off..(rk_off + 8)]);
+        sub_bytes_nots(&mut rkeys[rk_off..(rk_off + 8)]);
+
+        add_round_constant_bit(&mut rkeys[rk_off..(rk_off + 8)], rcon);
+        xor_columns(&mut rkeys, rk_off, 16, ror_distance(1, 3));
+        rcon += 1;
+
+        if rcon == 7 {
+            break;
+        }
+
+        memshift32(&mut rkeys, rk_off);
+        rk_off += 8;
+
+        sub_bytes(&mut rkeys[rk_off..(rk_off + 8)]);
+        sub_bytes_nots(&mut rkeys[rk_off..(rk_off + 8)]);
+
+        xor_columns(&mut rkeys, rk_off, 16, ror_distance(0, 3));
+    }
+
+    // Adjust to match fixslicing format (non-compact)
+    for i in (8..104).step_by(32) {
+        inv_shift_rows_1(&mut rkeys[i..(i + 8)]);
+        inv_shift_rows_2(&mut rkeys[(i + 8)..(i + 16)]);
+        inv_shift_rows_3(&mut rkeys[(i + 16)..(i + 24)]);
+    }
+    inv_shift_rows_1(&mut rkeys[104..112]);
+
+    // Account for NOTs removed from sub_bytes
+    for i in 1..15 {
+        sub_bytes_nots(&mut rkeys[(i * 8)..(i * 8 + 8)]);
+    }
+
+    RoundKeys256(rkeys)
+}
+
+/// Encrypt a single block using AES-128 in the fixsliced representation.
+///
+/// The input block is duplicated into all four slots of the bitsliced state.
+/// After encryption, only the first block is returned.
+pub(super) fn encrypt128(rkeys: &RoundKeys128, block: &[u8; 16]) -> [u8; 16] {
+    let mut state = [0u64; 8];
+    bitslice(&mut state, block, block, block, block);
+
+    add_round_key(&mut state, &rkeys.0[..8]);
+
+    let mut rk_off = 8;
+    loop {
+        sub_bytes(&mut state);
+        mix_columns_1(&mut state);
+        add_round_key(&mut state, &rkeys.0[rk_off..(rk_off + 8)]);
+        rk_off += 8;
+
+        if rk_off == 80 {
+            break;
+        }
+
+        sub_bytes(&mut state);
+        mix_columns_2(&mut state);
+        add_round_key(&mut state, &rkeys.0[rk_off..(rk_off + 8)]);
+        rk_off += 8;
+
+        sub_bytes(&mut state);
+        mix_columns_3(&mut state);
+        add_round_key(&mut state, &rkeys.0[rk_off..(rk_off + 8)]);
+        rk_off += 8;
+
+        sub_bytes(&mut state);
+        mix_columns_0(&mut state);
+        add_round_key(&mut state, &rkeys.0[rk_off..(rk_off + 8)]);
+        rk_off += 8;
+    }
+
+    shift_rows_2(&mut state);
+    sub_bytes(&mut state);
+    add_round_key(&mut state, &rkeys.0[80..]);
+
+    inv_bitslice(&state)[0]
+}
+
+/// Decrypt a single block using AES-128 in the fixsliced representation.
+///
+/// The input block is duplicated into all four slots of the bitsliced state.
+/// After decryption, only the first block is returned.
+pub(super) fn decrypt128(rkeys: &RoundKeys128, block: &[u8; 16]) -> [u8; 16] {
+    let mut state = [0u64; 8];
+    bitslice(&mut state, block, block, block, block);
+
+    add_round_key(&mut state, &rkeys.0[80..]);
+    inv_sub_bytes(&mut state);
+    inv_shift_rows_2(&mut state);
+
+    let mut rk_off = 72;
+    loop {
+        add_round_key(&mut state, &rkeys.0[rk_off..(rk_off + 8)]);
+        inv_mix_columns_1(&mut state);
+        inv_sub_bytes(&mut state);
+        rk_off -= 8;
+
+        if rk_off == 0 {
+            break;
+        }
+
+        add_round_key(&mut state, &rkeys.0[rk_off..(rk_off + 8)]);
+        inv_mix_columns_0(&mut state);
+        inv_sub_bytes(&mut state);
+        rk_off -= 8;
+
+        add_round_key(&mut state, &rkeys.0[rk_off..(rk_off + 8)]);
+        inv_mix_columns_3(&mut state);
+        inv_sub_bytes(&mut state);
+        rk_off -= 8;
+
+        add_round_key(&mut state, &rkeys.0[rk_off..(rk_off + 8)]);
+        inv_mix_columns_2(&mut state);
+        inv_sub_bytes(&mut state);
+        rk_off -= 8;
+    }
+
+    add_round_key(&mut state, &rkeys.0[..8]);
+
+    inv_bitslice(&state)[0]
+}
+
+/// Encrypt a single block using AES-256 in the fixsliced representation.
+///
+/// The input block is duplicated into all four slots of the bitsliced state.
+/// After encryption, only the first block is returned.
+pub(super) fn encrypt256(rkeys: &RoundKeys256, block: &[u8; 16]) -> [u8; 16] {
+    let mut state = [0u64; 8];
+    bitslice(&mut state, block, block, block, block);
+
+    add_round_key(&mut state, &rkeys.0[..8]);
+
+    let mut rk_off = 8;
+    loop {
+        sub_bytes(&mut state);
+        mix_columns_1(&mut state);
+        add_round_key(&mut state, &rkeys.0[rk_off..(rk_off + 8)]);
+        rk_off += 8;
+
+        if rk_off == 112 {
+            break;
+        }
+
+        sub_bytes(&mut state);
+        mix_columns_2(&mut state);
+        add_round_key(&mut state, &rkeys.0[rk_off..(rk_off + 8)]);
+        rk_off += 8;
+
+        sub_bytes(&mut state);
+        mix_columns_3(&mut state);
+        add_round_key(&mut state, &rkeys.0[rk_off..(rk_off + 8)]);
+        rk_off += 8;
+
+        sub_bytes(&mut state);
+        mix_columns_0(&mut state);
+        add_round_key(&mut state, &rkeys.0[rk_off..(rk_off + 8)]);
+        rk_off += 8;
+    }
+
+    shift_rows_2(&mut state);
+    sub_bytes(&mut state);
+    add_round_key(&mut state, &rkeys.0[112..]);
+
+    inv_bitslice(&state)[0]
+}
+
+/// Decrypt a single block using AES-256 in the fixsliced representation.
+///
+/// The input block is duplicated into all four slots of the bitsliced state.
+/// After decryption, only the first block is returned.
+pub(super) fn decrypt256(rkeys: &RoundKeys256, block: &[u8; 16]) -> [u8; 16] {
+    let mut state = [0u64; 8];
+    bitslice(&mut state, block, block, block, block);
+
+    add_round_key(&mut state, &rkeys.0[112..]);
+    inv_sub_bytes(&mut state);
+    inv_shift_rows_2(&mut state);
+
+    let mut rk_off = 104;
+    loop {
+        add_round_key(&mut state, &rkeys.0[rk_off..(rk_off + 8)]);
+        inv_mix_columns_1(&mut state);
+        inv_sub_bytes(&mut state);
+        rk_off -= 8;
+
+        if rk_off == 0 {
+            break;
+        }
+
+        add_round_key(&mut state, &rkeys.0[rk_off..(rk_off + 8)]);
+        inv_mix_columns_0(&mut state);
+        inv_sub_bytes(&mut state);
+        rk_off -= 8;
+
+        add_round_key(&mut state, &rkeys.0[rk_off..(rk_off + 8)]);
+        inv_mix_columns_3(&mut state);
+        inv_sub_bytes(&mut state);
+        rk_off -= 8;
+
+        add_round_key(&mut state, &rkeys.0[rk_off..(rk_off + 8)]);
+        inv_mix_columns_2(&mut state);
+        inv_sub_bytes(&mut state);
+        rk_off -= 8;
+    }
+
+    add_round_key(&mut state, &rkeys.0[..8]);
+
+    inv_bitslice(&state)[0]
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,6 +46,9 @@ extern crate alloc;
 #[macro_use]
 extern crate std;
 
+#[cfg(feature = "aes")]
+pub mod aes;
+
 #[cfg(feature = "blake2")]
 pub mod blake2b;
 


### PR DESCRIPTION
This is using a fixslice implementation (some bits similar to RustCrypto AES implementation) and an aarch64 AES implementation.

Note that AES192 is not implemented at this time